### PR TITLE
Add ability to toggle it in the Services menu and with keyboard shortcut

### DIFF
--- a/Touch Bar Simulator/Info.plist
+++ b/Touch Bar Simulator/Info.plist
@@ -38,10 +38,10 @@
 			<key>NSMenuItem</key>
 			<dict>
 				<key>default</key>
-				<string>Show Touch Bar</string>
+				<string>Toggle Touch Bar</string>
 			</dict>
 			<key>NSMessage</key>
-			<string></string>
+			<string>toggleView</string>
 			<key>NSPortName</key>
 			<string>Touch Bar Simulator</string>
 		</dict>

--- a/Touch Bar Simulator/Info.plist
+++ b/Touch Bar Simulator/Info.plist
@@ -30,6 +30,22 @@
 	<string>MIT License © Sindre Sorhus</string>
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
+	<key>NSServices</key>
+	<array>
+		<dict>
+			<key>NSKeyEquivalent</key>
+			<dict/>
+			<key>NSMenuItem</key>
+			<dict>
+				<key>default</key>
+				<string>Show Touch Bar</string>
+			</dict>
+			<key>NSMessage</key>
+			<string></string>
+			<key>NSPortName</key>
+			<string>Touch Bar Simulator</string>
+		</dict>
+	</array>
 	<key>SUEnableAutomaticChecks</key>
 	<true/>
 	<key>SUFeedURL</key>

--- a/Touch Bar Simulator/main.swift
+++ b/Touch Bar Simulator/main.swift
@@ -20,6 +20,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
 		toolbarView = controller.window!.standardWindowButton(.closeButton)!.superview!
 		addScreenshotButton()
 		addTransparencySlider()
+		NSApp.servicesProvider = self
 	}
 
 	func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {

--- a/Touch Bar Simulator/main.swift
+++ b/Touch Bar Simulator/main.swift
@@ -14,13 +14,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
 	var toolbarView: NSView!
 
 	func applicationDidFinishLaunching(_ notification: Notification) {
+		NSApp.servicesProvider = self
+		
 		_ = SUUpdater()
 
 		controller.window?.delegate = self
 		toolbarView = controller.window!.standardWindowButton(.closeButton)!.superview!
 		addScreenshotButton()
 		addTransparencySlider()
-		NSApp.servicesProvider = self
 	}
 
 	func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {

--- a/Touch Bar Simulator/main.swift
+++ b/Touch Bar Simulator/main.swift
@@ -68,6 +68,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
 		controller.window!.alphaValue = CGFloat(sender.doubleValue)
 		UserDefaults.standard.set(sender.doubleValue, forKey: "windowTransparency")
 	}
+    
+	@objc func toggleView(_ pboard: NSPasteboard, userData: String, error: NSErrorPointer) {
+		let a = controller.window!.isVisible
+		controller.window!.setIsVisible(!a)
+	}
 }
 
 let app = NSApplication.shared()

--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,9 @@
 
 > Use the Touch Bar on any Mac
 
-Launch the Touch Bar simulator from anywhere without needing to have Xcode installed, whereas Apple requires you to launch it from inside Xcode. It also comes with a handy transparency slider, a screenshot button and a service to toggle the Touch Bar in Services menu or with a keystroke. You can add it in System Preferences -> Keyboard -> Shortcuts -> Services -> Toggle Touch Bar.
+Launch the Touch Bar simulator from anywhere without needing to have Xcode installed, whereas Apple requires you to launch it from inside Xcode. It also comes with a handy transparency slider, a screenshot button, and a service to toggle the Touch Bar in the Services menu or with a keyboard shortcut.
+
+You can add a shortcut in `System Preferences` → `Keyboard` → `Shortcuts` → `Services` → `Toggle Touch Bar`.
 
 **[Discuss it on Product Hunt](https://www.producthunt.com/posts/touch-bar-simulator)**
 
@@ -44,6 +46,7 @@ You can capture a screenshot of the Touch Bar by either:
 - Signed binary
 - Transparency slider
 - Screenshot button
+- Doesn't steal focus when launched
 - Doesn't take up space in the Dock or app switcher
 
 ### Why is this not on the App Store?

--- a/readme.md
+++ b/readme.md
@@ -11,9 +11,18 @@ Launch the Touch Bar simulator from anywhere without needing to have Xcode insta
 *Check out my other macOS app → [Battery Indicator](https://itunes.apple.com/no/app/battery-indicator/id1206020918?mt=12)*
 
 
-## Download
+## Getting started
 
-[Download the latest release.](https://github.com/sindresorhus/touch-bar-simulator/releases/latest)
+#### [Download the latest release](https://github.com/sindresorhus/touch-bar-simulator/releases/latest)
+
+---
+
+Or install it with [Homebrew-Cask](https://caskroom.github.io):
+
+```
+$ brew update && brew cask install touch-bar-simulator
+```
+
 
 *Requires macOS 10.12.2 or later.*
 

--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@
 
 > Use the Touch Bar on any Mac
 
-Launch the Touch Bar simulator from anywhere without needing to have Xcode installed, whereas Apple requires you to launch it from inside Xcode. It also comes with a handy transparency slider and screenshot button.
+Launch the Touch Bar simulator from anywhere without needing to have Xcode installed, whereas Apple requires you to launch it from inside Xcode. It also comes with a handy transparency slider, a screenshot button and a service to toggle the Touch Bar in Services menu or with a keystroke. You can add it in System Preferences -> Keyboard -> Shortcuts -> Services -> Toggle Touch Bar.
 
 **[Discuss it on Product Hunt](https://www.producthunt.com/posts/touch-bar-simulator)**
 
@@ -32,8 +32,8 @@ $ brew update && brew cask install touch-bar-simulator
 You can capture a screenshot of the Touch Bar by either:
 
 1. Clicking the screenshot button in the Touch Bar window which saves it to `~/Desktop`.
-2. Pressing <kbd>Command</kbd> <kbd>Shift</kbd> <kbd>6</kbd> which saves it to `~/Desktop`.
-3. Pressing <kbd>Command</kbd> <kbd>Control</kbd> <kbd>Shift</kbd> <kbd>6</kbd> which saves it to the clipboard.
+2. Pressing ⇧⌘6 which saves it to `~/Desktop`.
+3. Pressing ⌃⇧⌘6 which saves it to the clipboard.
 
 
 ## FAQ
@@ -44,7 +44,6 @@ You can capture a screenshot of the Touch Bar by either:
 - Signed binary
 - Transparency slider
 - Screenshot button
-- Doesn't steal focus when launched
 - Doesn't take up space in the Dock or app switcher
 
 ### Why is this not on the App Store?


### PR DESCRIPTION
Added service to show the Touch Bar by _Services_ menu. You can add also a keystroke in _System Preferences -> Keyboard -> Shortcuts -> Services -> Show Touch Bar_.

EDIT: Edited service in order to show/hide the Touch Bar. Now it's named _Toggle Touch Bar_.
There's only one problem: when you show the touch bar simulator you lose focus on your previous application and this is annoying.