### PR TITLE
Add menu bar item with hide/show and docking options

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,2 @@
 github "sparkle-project/Sparkle"
+github "sindresorhus/Defaults"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,1 +1,2 @@
-github "sparkle-project/Sparkle" "1.20.0"
+github "sindresorhus/Defaults" "v1.0.0"
+github "sparkle-project/Sparkle" "1.21.2"

--- a/Touch Bar Simulator.xcodeproj/project.pbxproj
+++ b/Touch Bar Simulator.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		3C37035421FBEBD300177657 /* Defaults.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3C37035321FBEBD300177657 /* Defaults.framework */; };
 		3C37035521FBEBD300177657 /* Defaults.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 3C37035321FBEBD300177657 /* Defaults.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		3C8493AD21FD3B7F00F12966 /* Glue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C8493AC21FD3B7F00F12966 /* Glue.swift */; };
 		AF6C7BC61E7FAF38004A27E0 /* ToolbarSlider.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF6C7BC51E7FAF38004A27E0 /* ToolbarSlider.swift */; };
 		E30988DF1E88DD060078CA9E /* Sparkle.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E30988DE1E88DD060078CA9E /* Sparkle.framework */; };
 		E30988E01E88DD060078CA9E /* Sparkle.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = E30988DE1E88DD060078CA9E /* Sparkle.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -44,6 +45,7 @@
 
 /* Begin PBXFileReference section */
 		3C37035321FBEBD300177657 /* Defaults.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Defaults.framework; path = Carthage/Build/Mac/Defaults.framework; sourceTree = "<group>"; };
+		3C8493AC21FD3B7F00F12966 /* Glue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Glue.swift; sourceTree = "<group>"; };
 		AF6C7BC51E7FAF38004A27E0 /* ToolbarSlider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = ToolbarSlider.swift; sourceTree = "<group>"; usesTabs = 1; };
 		E30988DE1E88DD060078CA9E /* Sparkle.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Sparkle.framework; path = Carthage/Build/Mac/Sparkle.framework; sourceTree = "<group>"; };
 		E34D6548214BBDAE00786C24 /* Touch Bar Simulator.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "Touch Bar Simulator.entitlements"; sourceTree = "<group>"; };
@@ -114,6 +116,7 @@
 				E35579EA21595EDC001CB642 /* TouchBarWindow.swift */,
 				E39A158D214D0C4F00F86D5D /* TouchBarView.swift */,
 				AF6C7BC51E7FAF38004A27E0 /* ToolbarSlider.swift */,
+				3C8493AC21FD3B7F00F12966 /* Glue.swift */,
 				E3930B0F216625BE00F66410 /* Constants.swift */,
 				E35831A31F4D7EE0003BE371 /* util.swift */,
 				E3FE2CC41E726CE800C6713A /* Assets.xcassets */,
@@ -233,6 +236,7 @@
 			files = (
 				E35831A41F4D7EE0003BE371 /* util.swift in Sources */,
 				AF6C7BC61E7FAF38004A27E0 /* ToolbarSlider.swift in Sources */,
+				3C8493AD21FD3B7F00F12966 /* Glue.swift in Sources */,
 				E356A16321028D81000148AD /* main.swift in Sources */,
 				E35579EB21595EDC001CB642 /* TouchBarWindow.swift in Sources */,
 				E3930B10216625BE00F66410 /* Constants.swift in Sources */,

--- a/Touch Bar Simulator.xcodeproj/project.pbxproj
+++ b/Touch Bar Simulator.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		3C37035421FBEBD300177657 /* Defaults.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3C37035321FBEBD300177657 /* Defaults.framework */; };
+		3C37035521FBEBD300177657 /* Defaults.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 3C37035321FBEBD300177657 /* Defaults.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		AF6C7BC61E7FAF38004A27E0 /* ToolbarSlider.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF6C7BC51E7FAF38004A27E0 /* ToolbarSlider.swift */; };
 		E30988DF1E88DD060078CA9E /* Sparkle.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E30988DE1E88DD060078CA9E /* Sparkle.framework */; };
 		E30988E01E88DD060078CA9E /* Sparkle.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = E30988DE1E88DD060078CA9E /* Sparkle.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -32,6 +34,7 @@
 			files = (
 				E30988E01E88DD060078CA9E /* Sparkle.framework in Embed Frameworks */,
 				E39A158B214D011F00F86D5D /* SkyLight.framework in Embed Frameworks */,
+				3C37035521FBEBD300177657 /* Defaults.framework in Embed Frameworks */,
 				E39A157F214CFE7100F86D5D /* DFRFoundation.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
@@ -40,6 +43,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		3C37035321FBEBD300177657 /* Defaults.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Defaults.framework; path = Carthage/Build/Mac/Defaults.framework; sourceTree = "<group>"; };
 		AF6C7BC51E7FAF38004A27E0 /* ToolbarSlider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = ToolbarSlider.swift; sourceTree = "<group>"; usesTabs = 1; };
 		E30988DE1E88DD060078CA9E /* Sparkle.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Sparkle.framework; path = Carthage/Build/Mac/Sparkle.framework; sourceTree = "<group>"; };
 		E34D6548214BBDAE00786C24 /* Touch Bar Simulator.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "Touch Bar Simulator.entitlements"; sourceTree = "<group>"; };
@@ -64,6 +68,7 @@
 			files = (
 				E39A157E214CFE7100F86D5D /* DFRFoundation.framework in Frameworks */,
 				E39A158A214D011F00F86D5D /* SkyLight.framework in Frameworks */,
+				3C37035421FBEBD300177657 /* Defaults.framework in Frameworks */,
 				E30988DF1E88DD060078CA9E /* Sparkle.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -121,6 +126,7 @@
 			isa = PBXGroup;
 			children = (
 				E30988DE1E88DD060078CA9E /* Sparkle.framework */,
+				3C37035321FBEBD300177657 /* Defaults.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";

--- a/Touch Bar Simulator.xcodeproj/project.pbxproj
+++ b/Touch Bar Simulator.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		E35579EB21595EDC001CB642 /* TouchBarWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = E35579EA21595EDC001CB642 /* TouchBarWindow.swift */; };
 		E356A16321028D81000148AD /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = E356A16221028D81000148AD /* main.swift */; };
 		E35831A41F4D7EE0003BE371 /* util.swift in Sources */ = {isa = PBXBuildFile; fileRef = E35831A31F4D7EE0003BE371 /* util.swift */; };
+		E3930B10216625BE00F66410 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3930B0F216625BE00F66410 /* Constants.swift */; };
 		E39A157E214CFE7100F86D5D /* DFRFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E39A157D214CFE7100F86D5D /* DFRFoundation.framework */; };
 		E39A157F214CFE7100F86D5D /* DFRFoundation.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = E39A157D214CFE7100F86D5D /* DFRFoundation.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		E39A158A214D011F00F86D5D /* SkyLight.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E39A1589214D011F00F86D5D /* SkyLight.framework */; };
@@ -42,12 +43,13 @@
 		AF6C7BC51E7FAF38004A27E0 /* ToolbarSlider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = ToolbarSlider.swift; sourceTree = "<group>"; usesTabs = 1; };
 		E30988DE1E88DD060078CA9E /* Sparkle.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Sparkle.framework; path = Carthage/Build/Mac/Sparkle.framework; sourceTree = "<group>"; };
 		E34D6548214BBDAE00786C24 /* Touch Bar Simulator.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "Touch Bar Simulator.entitlements"; sourceTree = "<group>"; };
-		E35579EA21595EDC001CB642 /* TouchBarWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TouchBarWindow.swift; sourceTree = "<group>"; };
+		E35579EA21595EDC001CB642 /* TouchBarWindow.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = TouchBarWindow.swift; sourceTree = "<group>"; usesTabs = 1; };
 		E356A16221028D81000148AD /* main.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = main.swift; sourceTree = "<group>"; usesTabs = 1; };
 		E35831A31F4D7EE0003BE371 /* util.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = util.swift; sourceTree = "<group>"; usesTabs = 1; };
+		E3930B0F216625BE00F66410 /* Constants.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = Constants.swift; sourceTree = "<group>"; usesTabs = 1; };
 		E39A157D214CFE7100F86D5D /* DFRFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = DFRFoundation.framework; path = ../../../../../System/Library/PrivateFrameworks/DFRFoundation.framework; sourceTree = "<group>"; };
 		E39A1589214D011F00F86D5D /* SkyLight.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SkyLight.framework; path = ../../../../../System/Library/PrivateFrameworks/SkyLight.framework; sourceTree = "<group>"; };
-		E39A158D214D0C4F00F86D5D /* TouchBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TouchBarView.swift; sourceTree = "<group>"; };
+		E39A158D214D0C4F00F86D5D /* TouchBarView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = TouchBarView.swift; sourceTree = "<group>"; usesTabs = 1; };
 		E3FE2CBF1E726CE800C6713A /* Touch Bar Simulator.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Touch Bar Simulator.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		E3FE2CC21E726CE800C6713A /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = AppDelegate.swift; sourceTree = "<group>"; usesTabs = 1; };
 		E3FE2CC41E726CE800C6713A /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -107,6 +109,7 @@
 				E35579EA21595EDC001CB642 /* TouchBarWindow.swift */,
 				E39A158D214D0C4F00F86D5D /* TouchBarView.swift */,
 				AF6C7BC51E7FAF38004A27E0 /* ToolbarSlider.swift */,
+				E3930B0F216625BE00F66410 /* Constants.swift */,
 				E35831A31F4D7EE0003BE371 /* util.swift */,
 				E3FE2CC41E726CE800C6713A /* Assets.xcassets */,
 				E356A16421028DAB000148AD /* Other */,
@@ -226,6 +229,7 @@
 				AF6C7BC61E7FAF38004A27E0 /* ToolbarSlider.swift in Sources */,
 				E356A16321028D81000148AD /* main.swift in Sources */,
 				E35579EB21595EDC001CB642 /* TouchBarWindow.swift in Sources */,
+				E3930B10216625BE00F66410 /* Constants.swift in Sources */,
 				E3FE2CC31E726CE800C6713A /* AppDelegate.swift in Sources */,
 				E39A158E214D0C4F00F86D5D /* TouchBarView.swift in Sources */,
 			);

--- a/Touch Bar Simulator/AppDelegate.swift
+++ b/Touch Bar Simulator/AppDelegate.swift
@@ -5,6 +5,7 @@ import Defaults
 final class AppDelegate: NSObject, NSApplicationDelegate {
 	lazy var window = with(TouchBarWindow()) {
 		$0.alphaValue = CGFloat(defaults[.windowTransparency])
+		$0.setUp()
 	}
 
 	lazy var statusItem = with(NSStatusBar.system.statusItem(withLength: NSStatusItem.squareLength)) {
@@ -21,28 +22,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
 	func applicationDidFinishLaunching(_ notification: Notification) {
 		NSApp.servicesProvider = self
-
 		_ = SUUpdater()
-
-		let view = window.contentView!
-		view.wantsLayer = true
-		view.layer?.backgroundColor = NSColor.black.cgColor
-
-		let touchBarView = TouchBarView()
-		window.setContentSize(touchBarView.bounds.adding(padding: 5).size)
-		touchBarView.frame = touchBarView.frame.centered(in: view.bounds)
-		view.addSubview(touchBarView)
-
-		window.center()
-		var origin = window.frame.origin
-		origin.y = 100
-		window.setFrameOrigin(origin)
-
-		window.setFrameUsingName(Constants.windowAutosaveName)
-		window.setFrameAutosaveName(Constants.windowAutosaveName)
-
-		window.orderFront(nil)
-
 		_ = statusItem
 
 		docking = defaults[.windowDocking]

--- a/Touch Bar Simulator/AppDelegate.swift
+++ b/Touch Bar Simulator/AppDelegate.swift
@@ -8,13 +8,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 	}
 
 	lazy var statusItem = with(NSStatusBar.system.statusItem(withLength: NSStatusItem.squareLength)) {
-		$0.menu = statusMenu
+		$0.menu = with(NSMenu()) { $0.delegate = self }
 		$0.button!.image = NSImage(named: "AppIcon") // TODO: Add proper icon
 		$0.button!.toolTip = "Right or option-click for menu"
-	}
-	lazy var statusMenu = with(NSMenu()) {
-		createMenuItems() // Items added/removed conditionally in menuNeedsUpdate(_:)
-		$0.delegate = self
 	}
 
 	func applicationWillFinishLaunching(_ notification: Notification) {
@@ -68,30 +64,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 		window.setIsVisible(!window.isVisible)
 	}
 
-	private var statusMenuItemFloating: NSMenuItem!
-	private var statusMenuItemDockedToTop: NSMenuItem!
-	private var statusMenuItemDockedToBottom: NSMenuItem!
-	private var statusMenuDockingItems: [NSMenuItem]!
-	private var statusMenuItemShowOnAllDesktops: NSMenuItem!
-	private var statusMenuItems: [NSMenuItem]!
-
 	var docking: TouchBarWindow.Docking = .floating {
 		didSet {
 			defaults[.windowDocking] = docking
-
-			statusMenuDockingItems.forEach { $0.state = .off }
-
-			let onItem: NSMenuItem
-			switch docking {
-			case .floating:
-				onItem = statusMenuItemFloating
-			case .dockedToTop:
-				onItem = statusMenuItemDockedToTop
-			case .dockedToBottom:
-				onItem = statusMenuItemDockedToBottom
-			}
-			onItem.state = .on
-
 			window.docking = docking
 		}
 	}
@@ -99,7 +74,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 	var showOnAllDesktops: Bool = false {
 		didSet {
 			defaults[.showOnAllDesktops] = showOnAllDesktops
-			statusMenuItemShowOnAllDesktops.state = showOnAllDesktops ? .on : .off
 			window.showOnAllDesktops = showOnAllDesktops
 		}
 	}
@@ -107,39 +81,35 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 }
 
 extension AppDelegate: NSMenuDelegate {
-	func createMenuItems() {
-		func menuItem(_ title: String, keyEquivalent: String = "", action: @escaping TargetActionSender.ActionClosure) -> NSMenuItem {
-			let item = NSMenuItem(title: title, action: nil, keyEquivalent: keyEquivalent)
-			item.onAction = action
-			return item
+	private func update(menu: NSMenu) {
+		menu.removeAllItems()
+
+		guard statusItemShouldShowMenu() else {
+			return
 		}
 
-		statusMenuItemFloating = menuItem("Floating") { _ in
+		menu.addItem(NSMenuItem(title: "Docking", action: nil, keyEquivalent: ""))
+		var statusMenuDockingItems: [NSMenuItem] = []
+		statusMenuDockingItems.append(NSMenuItem.menuItem("Floating", isOn: docking == .floating) { _ in
 			self.docking = .floating
-		}
-		statusMenuItemDockedToTop = menuItem("Docked to Top") { _ in
+		})
+		statusMenuDockingItems.append(NSMenuItem.menuItem("Docked to Top", isOn: docking == .dockedToTop) { _ in
 			self.docking = .dockedToTop
-		}
-		statusMenuItemDockedToBottom = menuItem("Docked to Bottom") { _ in
+		})
+		statusMenuDockingItems.append(NSMenuItem.menuItem("Docked to Bottom", isOn: docking == .dockedToBottom) { _ in
 			self.docking = .dockedToBottom
-		}
-		statusMenuDockingItems = [
-			statusMenuItemFloating,
-			statusMenuItemDockedToTop,
-			statusMenuItemDockedToBottom
-		]
+		})
 		for item in statusMenuDockingItems {
 			item.indentationLevel = 1
 		}
+		menu.items.append(contentsOf: statusMenuDockingItems)
 
-		let takeScreenshotItem = menuItem("Take Screenshot") { _ in
-			self.captureScreenshot()
-		}
-		let transparencyItem = menuItem("Transparency") { _ in }
+		menu.addItem(NSMenuItem(title: "Transparency", action: nil, keyEquivalent: ""))
+		let transparencyItem = NSMenuItem.menuItem("Transparency") { _ in }
 		let transparencyView = NSView(frame: CGRect(origin: .zero, size: CGSize(width: 180, height: 20)))
 		let slider = window.makeTransparencySlider(transparencyView)
 		slider.onAction = { sender in
-			self.window.setTransparency(sender: sender as! ToolbarSlider)
+			self.window.setTransparency(sender: sender)
 		}
 		transparencyView.addSubview(slider)
 		slider.translatesAutoresizingMaskIntoConstraints = false
@@ -147,36 +117,26 @@ extension AppDelegate: NSMenuDelegate {
 		slider.trailingAnchor.constraint(equalTo: transparencyView.trailingAnchor, constant: -20).isActive = true
 		slider.centerYAnchor.constraint(equalTo: transparencyView.centerYAnchor).isActive = true
 		transparencyItem.view = transparencyView
+		menu.addItem(transparencyItem)
 
-		statusMenuItemShowOnAllDesktops = menuItem("Show on All Desktops") { _ in
+		menu.addItem(NSMenuItem.separator())
+
+		menu.addItem(NSMenuItem.menuItem("Take Screenshot", keyEquivalent: "6", keyModifiers: [.shift, .command]) { _ in
+			self.captureScreenshot()
+		})
+
+		menu.addItem(NSMenuItem.separator())
+
+		let showOnAllDesktopsItem = NSMenuItem.menuItem("Show on All Desktops", isOn: defaults[.showOnAllDesktops]) { _ in
 			self.showOnAllDesktops = !self.showOnAllDesktops
 		}
+		menu.addItem(showOnAllDesktopsItem)
 
-		let quitItem = menuItem("Quit Touch Bar Simulator", keyEquivalent: "q") { _ in
+		menu.addItem(NSMenuItem.separator())
+
+		menu.addItem(NSMenuItem.menuItem("Quit Touch Bar Simulator", keyEquivalent: "q") { _ in
 			NSApp.terminate(nil)
-		}
-
-		statusMenuItems = [
-			NSMenuItem(title: "Docking", action: nil, keyEquivalent: ""),
-			statusMenuItemFloating,
-			statusMenuItemDockedToTop,
-			statusMenuItemDockedToBottom,
-
-			NSMenuItem(title: "Transparency", action: nil, keyEquivalent: ""),
-			transparencyItem,
-
-			NSMenuItem.separator(),
-
-			takeScreenshotItem,
-
-			NSMenuItem.separator(),
-
-			statusMenuItemShowOnAllDesktops,
-
-			NSMenuItem.separator(),
-
-			quitItem
-		]
+		})
 	}
 
 	private func statusItemShouldShowMenu() -> Bool {
@@ -184,14 +144,7 @@ extension AppDelegate: NSMenuDelegate {
 	}
 
 	func menuNeedsUpdate(_ menu: NSMenu) {
-		guard statusItemShouldShowMenu() else {
-			menu.removeAllItems()
-			return
-		}
-		guard menu.numberOfItems != statusMenuItems.count else {
-			return
-		}
-		menu.items = statusMenuItems
+		update(menu: menu)
 	}
 
 	func menuWillOpen(_ menu: NSMenu) {

--- a/Touch Bar Simulator/AppDelegate.swift
+++ b/Touch Bar Simulator/AppDelegate.swift
@@ -53,9 +53,9 @@ extension AppDelegate: NSMenuDelegate {
 
 		menu.addItem(NSMenuItem(title: "Docking", action: nil, keyEquivalent: ""))
 		var statusMenuDockingItems: [NSMenuItem] = []
-		statusMenuDockingItems.append(NSMenuItem("Floating").bindChoice(to: .windowDocking, value: .floating))
-		statusMenuDockingItems.append(NSMenuItem("Docked to Top").bindChoice(to: .windowDocking, value: .dockedToTop))
-		statusMenuDockingItems.append(NSMenuItem("Docked to Bottom").bindChoice(to: .windowDocking, value: .dockedToBottom))
+		statusMenuDockingItems.append(NSMenuItem("Floating").streamChoice(to: .windowDocking, value: .floating))
+		statusMenuDockingItems.append(NSMenuItem("Docked to Top").streamChoice(to: .windowDocking, value: .dockedToTop))
+		statusMenuDockingItems.append(NSMenuItem("Docked to Bottom").streamChoice(to: .windowDocking, value: .dockedToBottom))
 		for item in statusMenuDockingItems {
 			item.indentationLevel = 1
 		}
@@ -87,7 +87,7 @@ extension AppDelegate: NSMenuDelegate {
 
 		menu.addItem(NSMenuItem.separator())
 
-		menu.addItem(NSMenuItem("Show on All Desktops").bindToggle(to: .showOnAllDesktops))
+		menu.addItem(NSMenuItem("Show on All Desktops").streamState(to: .showOnAllDesktops))
 
 		menu.addItem(NSMenuItem.separator())
 

--- a/Touch Bar Simulator/AppDelegate.swift
+++ b/Touch Bar Simulator/AppDelegate.swift
@@ -64,7 +64,7 @@ extension AppDelegate: NSMenuDelegate {
 
 		menu.addItem(NSMenuItem(title: "Transparency", action: nil, keyEquivalent: ""))
 		let transparencyItem = NSMenuItem.menuItem("Transparency") { _ in }
-		let transparencyView = NSView(frame: CGRect(origin: .zero, size: CGSize(width: 180, height: 20)))
+		let transparencyView = NSView(frame: CGRect(origin: .zero, size: CGSize(width: 200, height: 20)))
 		let slider = ToolbarSlider()
 		slider.frame = CGRect(x: 20, y: 4, width: 180, height: 11)
 		slider.onAction = { sender in
@@ -74,8 +74,8 @@ extension AppDelegate: NSMenuDelegate {
 		slider.doubleValue = defaults[.windowTransparency]
 		transparencyView.addSubview(slider)
 		slider.translatesAutoresizingMaskIntoConstraints = false
-		slider.leadingAnchor.constraint(equalTo: transparencyView.leadingAnchor, constant: 40).isActive = true
-		slider.trailingAnchor.constraint(equalTo: transparencyView.trailingAnchor, constant: -20).isActive = true
+		slider.leadingAnchor.constraint(equalTo: transparencyView.leadingAnchor, constant: 33).isActive = true
+		slider.trailingAnchor.constraint(equalTo: transparencyView.trailingAnchor, constant: -18).isActive = true
 		slider.centerYAnchor.constraint(equalTo: transparencyView.centerYAnchor).isActive = true
 		transparencyItem.view = transparencyView
 		menu.addItem(transparencyItem)

--- a/Touch Bar Simulator/AppDelegate.swift
+++ b/Touch Bar Simulator/AppDelegate.swift
@@ -37,14 +37,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 			makeTransparencySlider()
 		)
 
-		if window.frameAutosaveName.isEmpty {
-			window.center()
-			var origin = window.frame.origin
-			origin.y = 100
-			window.setFrameOrigin(origin)
-		}
+		window.center()
+		var origin = window.frame.origin
+		origin.y = 100
+		window.setFrameOrigin(origin)
 
-		window.setFrameAutosaveName("TouchBarWindowfoo4")
+		window.setFrameUsingName(Constants.windowAutosaveName)
+		window.setFrameAutosaveName(Constants.windowAutosaveName)
+
 		window.orderFront(nil)
 	}
 

--- a/Touch Bar Simulator/AppDelegate.swift
+++ b/Touch Bar Simulator/AppDelegate.swift
@@ -64,18 +64,7 @@ extension AppDelegate: NSMenuDelegate {
 		menu.addItem(NSMenuItem(title: "Transparency", action: nil, keyEquivalent: ""))
 		let transparencyItem = NSMenuItem("Transparency")
 		let transparencyView = NSView(frame: CGRect(origin: .zero, size: CGSize(width: 200, height: 20)))
-		let slider = MenubarSlider()
-		slider.onAction = { sender in
-			// Redisplaying the slider prevents shadow artifacts that result
-			// from moving a knob that draws a shadow
-			// However, only do so if its value has changed, because if a
-			// redisplay is attempted without a change, then the slider draws
-			// itself brighter for some reason
-			if (defaults[.windowTransparency] - sender.doubleValue) != 0 {
-				sender.needsDisplay = true
-			}
-		}
-		_ = slider.streamDoubleValue(to: .windowTransparency)
+		let slider = MenubarSlider().alwaysRedisplayOnValueChanged().streamDoubleValue(to: .windowTransparency)
 		slider.frame = CGRect(x: 20, y: 4, width: 180, height: 11)
 		slider.minValue = 0.5
 		transparencyView.addSubview(slider)

--- a/Touch Bar Simulator/AppDelegate.swift
+++ b/Touch Bar Simulator/AppDelegate.swift
@@ -11,7 +11,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 	lazy var statusItem = with(NSStatusBar.system.statusItem(withLength: NSStatusItem.squareLength)) {
 		$0.menu = statusMenu
 		$0.button!.image = NSImage(named: "AppIcon") // TODO: Add proper icon
-		$0.button!.toolTip = NSLocalizedString("Right or option-click for menu", comment: "Status bar item tooltip")
+		$0.button!.toolTip = "Right or option-click for menu";
 	}
 	lazy var statusMenu = with(NSMenu()) {
 		$0.delegate = self
@@ -129,20 +129,20 @@ private func statusItemShouldShowMenu() -> Bool {
 	return !leftMouseIsDown() || optionKeyIsDown()
 }
 
-private var statusMenuDockingItemFloating = NSMenuItem(title: NSLocalizedString("Floating", comment: "Status menu Docking item"), action: #selector(AppDelegate.setFloating), keyEquivalent: "")
-private var statusMenuDockingItemDockedToTop = NSMenuItem(title: NSLocalizedString("Docked to Top", comment: "Status menu Docking item"), action: #selector(AppDelegate.setDockedToTop), keyEquivalent: "")
-private var statusMenuDockingItemDockedToBottom = NSMenuItem(title: NSLocalizedString("Docked to Bottom", comment: "Status menu Docking item"), action: #selector(AppDelegate.setDockedToBottom), keyEquivalent: "")
+private var statusMenuDockingItemFloating = NSMenuItem(title: "Floating", action: #selector(AppDelegate.setFloating), keyEquivalent: "")
+private var statusMenuDockingItemDockedToTop = NSMenuItem(title: "Docked to Top", action: #selector(AppDelegate.setDockedToTop), keyEquivalent: "")
+private var statusMenuDockingItemDockedToBottom = NSMenuItem(title: "Docked to Bottom", action: #selector(AppDelegate.setDockedToBottom), keyEquivalent: "")
 private var statusMenuDockingItems: [NSMenuItem] = [
 	statusMenuDockingItemFloating,
 	statusMenuDockingItemDockedToTop,
 	statusMenuDockingItemDockedToBottom
 ].map { $0.indentationLevel = 1; return $0 }
 
-private var statusMenuItemShowOnAllDesktops = NSMenuItem(title: NSLocalizedString("Show on All Desktops", comment: "Status menu item"), action: #selector(AppDelegate.toggleShowOnAllDesktops), keyEquivalent: "")
+private var statusMenuItemShowOnAllDesktops = NSMenuItem(title: "Show on All Desktops", action: #selector(AppDelegate.toggleShowOnAllDesktops), keyEquivalent: "")
 
 private var statusMenuOptionItems: [NSMenuItem] = [
 
-	NSMenuItem(title: NSLocalizedString("Docking", comment: "Status menu label item"), action: nil, keyEquivalent: ""),
+	NSMenuItem(title: "Docking", action: nil, keyEquivalent: ""),
 	statusMenuDockingItemFloating,
 	statusMenuDockingItemDockedToTop,
 	statusMenuDockingItemDockedToBottom,
@@ -153,7 +153,7 @@ private var statusMenuOptionItems: [NSMenuItem] = [
 
 	NSMenuItem.separator(),
 
-	NSMenuItem(title: NSLocalizedString("Quit Touch Bar Simulator", comment: "Status menu item"), action: #selector(NSApplication.terminate(_:)), keyEquivalent: "")
+	NSMenuItem(title: "Quit Touch Bar Simulator", action: #selector(NSApplication.terminate(_:)), keyEquivalent: "")
 
 ]
 

--- a/Touch Bar Simulator/AppDelegate.swift
+++ b/Touch Bar Simulator/AppDelegate.swift
@@ -23,6 +23,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 	func applicationDidFinishLaunching(_ notification: Notification) {
 		NSApp.servicesProvider = self
 		_ = SUUpdater()
+		_ = window
 		_ = statusItem
 	}
 
@@ -94,7 +95,7 @@ extension AppDelegate: NSMenuDelegate {
 	}
 
 	private func statusItemShouldShowMenu() -> Bool {
-		return !NSApp.leftMouseIsDown() || NSApp.optionKeyIsDown()
+		return !NSApp.isLeftMouseDown || NSApp.isOptionKeyDown
 	}
 
 	func menuNeedsUpdate(_ menu: NSMenu) {

--- a/Touch Bar Simulator/AppDelegate.swift
+++ b/Touch Bar Simulator/AppDelegate.swift
@@ -65,7 +65,7 @@ extension AppDelegate: NSMenuDelegate {
 		menu.addItem(NSMenuItem(title: "Transparency", action: nil, keyEquivalent: ""))
 		let transparencyItem = NSMenuItem.menuItem("Transparency") { _ in }
 		let transparencyView = NSView(frame: CGRect(origin: .zero, size: CGSize(width: 200, height: 20)))
-		let slider = ToolbarSlider()
+		let slider = MenubarSlider()
 		slider.frame = CGRect(x: 20, y: 4, width: 180, height: 11)
 		slider.onAction = { sender in
 			defaults[.windowTransparency] = sender.doubleValue

--- a/Touch Bar Simulator/AppDelegate.swift
+++ b/Touch Bar Simulator/AppDelegate.swift
@@ -53,9 +53,9 @@ extension AppDelegate: NSMenuDelegate {
 
 		menu.addItem(NSMenuItem(title: "Docking", action: nil, keyEquivalent: ""))
 		var statusMenuDockingItems: [NSMenuItem] = []
-		statusMenuDockingItems.append(NSMenuItem("Floating").bindActivation(to: .windowDocking, value: .floating))
-		statusMenuDockingItems.append(NSMenuItem("Docked to Top").bindActivation(to: .windowDocking, value: .dockedToTop))
-		statusMenuDockingItems.append(NSMenuItem("Docked to Bottom").bindActivation(to: .windowDocking, value: .dockedToBottom))
+		statusMenuDockingItems.append(NSMenuItem("Floating").bindChoice(to: .windowDocking, value: .floating))
+		statusMenuDockingItems.append(NSMenuItem("Docked to Top").bindChoice(to: .windowDocking, value: .dockedToTop))
+		statusMenuDockingItems.append(NSMenuItem("Docked to Bottom").bindChoice(to: .windowDocking, value: .dockedToBottom))
 		for item in statusMenuDockingItems {
 			item.indentationLevel = 1
 		}

--- a/Touch Bar Simulator/AppDelegate.swift
+++ b/Touch Bar Simulator/AppDelegate.swift
@@ -155,7 +155,7 @@ extension AppDelegate: NSMenuDelegate {
 			quitItem
 		]
 	}
-	
+
 	private func statusItemShouldShowMenu() -> Bool {
 		return !NSApp.leftMouseIsDown() || NSApp.optionKeyIsDown()
 	}

--- a/Touch Bar Simulator/AppDelegate.swift
+++ b/Touch Bar Simulator/AppDelegate.swift
@@ -65,10 +65,13 @@ extension AppDelegate: NSMenuDelegate {
 		menu.addItem(NSMenuItem(title: "Transparency", action: nil, keyEquivalent: ""))
 		let transparencyItem = NSMenuItem.menuItem("Transparency") { _ in }
 		let transparencyView = NSView(frame: CGRect(origin: .zero, size: CGSize(width: 180, height: 20)))
-		let slider = window.makeTransparencySlider(transparencyView)
+		let slider = ToolbarSlider()
+		slider.frame = CGRect(x: 20, y: 4, width: 180, height: 11)
 		slider.onAction = { sender in
-			self.window.setTransparency(sender: sender)
+			defaults[.windowTransparency] = sender.doubleValue
 		}
+		slider.minValue = 0.5
+		slider.doubleValue = defaults[.windowTransparency]
 		transparencyView.addSubview(slider)
 		slider.translatesAutoresizingMaskIntoConstraints = false
 		slider.leadingAnchor.constraint(equalTo: transparencyView.leadingAnchor, constant: 40).isActive = true

--- a/Touch Bar Simulator/AppDelegate.swift
+++ b/Touch Bar Simulator/AppDelegate.swift
@@ -41,7 +41,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 	func toggleView() {
 		window.setIsVisible(!window.isVisible)
 	}
-
 }
 
 extension AppDelegate: NSMenuDelegate {
@@ -54,16 +53,16 @@ extension AppDelegate: NSMenuDelegate {
 
 		menu.addItem(NSMenuItem(title: "Docking", action: nil, keyEquivalent: ""))
 		var statusMenuDockingItems: [NSMenuItem] = []
-		statusMenuDockingItems.append(NSMenuItem.menuItem("Floating").bindActivation(to: .windowDocking, value: .floating))
-		statusMenuDockingItems.append(NSMenuItem.menuItem("Docked to Top").bindActivation(to: .windowDocking, value: .dockedToTop))
-		statusMenuDockingItems.append(NSMenuItem.menuItem("Docked to Bottom").bindActivation(to: .windowDocking, value: .dockedToBottom))
+		statusMenuDockingItems.append(NSMenuItem("Floating").bindActivation(to: .windowDocking, value: .floating))
+		statusMenuDockingItems.append(NSMenuItem("Docked to Top").bindActivation(to: .windowDocking, value: .dockedToTop))
+		statusMenuDockingItems.append(NSMenuItem("Docked to Bottom").bindActivation(to: .windowDocking, value: .dockedToBottom))
 		for item in statusMenuDockingItems {
 			item.indentationLevel = 1
 		}
 		menu.items.append(contentsOf: statusMenuDockingItems)
 
 		menu.addItem(NSMenuItem(title: "Transparency", action: nil, keyEquivalent: ""))
-		let transparencyItem = NSMenuItem.menuItem("Transparency") { _ in }
+		let transparencyItem = NSMenuItem("Transparency")
 		let transparencyView = NSView(frame: CGRect(origin: .zero, size: CGSize(width: 200, height: 20)))
 		let slider = MenubarSlider()
 		slider.frame = CGRect(x: 20, y: 4, width: 180, height: 11)
@@ -82,17 +81,17 @@ extension AppDelegate: NSMenuDelegate {
 
 		menu.addItem(NSMenuItem.separator())
 
-		menu.addItem(NSMenuItem.menuItem("Take Screenshot", keyEquivalent: "6", keyModifiers: [.shift, .command]) { _ in
+		menu.addItem(NSMenuItem("Take Screenshot", keyEquivalent: "6", keyModifiers: [.shift, .command]) { _ in
 			self.captureScreenshot()
 		})
 
 		menu.addItem(NSMenuItem.separator())
 
-		menu.addItem(NSMenuItem.menuItem("Show on All Desktops").bindToggle(to: .showOnAllDesktops))
+		menu.addItem(NSMenuItem("Show on All Desktops").bindToggle(to: .showOnAllDesktops))
 
 		menu.addItem(NSMenuItem.separator())
 
-		menu.addItem(NSMenuItem.menuItem("Quit Touch Bar Simulator", keyEquivalent: "q") { _ in
+		menu.addItem(NSMenuItem("Quit Touch Bar Simulator", keyEquivalent: "q") { _ in
 			NSApp.terminate(nil)
 		})
 	}

--- a/Touch Bar Simulator/AppDelegate.swift
+++ b/Touch Bar Simulator/AppDelegate.swift
@@ -132,6 +132,22 @@ extension AppDelegate: NSMenuDelegate {
 			item.indentationLevel = 1
 		}
 
+		let takeScreenshotItem = menuItem("Take Screenshot") { _ in
+			self.captureScreenshot()
+		}
+		let transparencyItem = menuItem("Transparency") { _ in }
+		let transparencyView = NSView(frame: CGRect(origin: .zero, size: CGSize(width: 180, height: 20)))
+		let slider = window.makeTransparencySlider(transparencyView)
+		slider.onAction = { sender in
+			self.window.setTransparency(sender: sender as! ToolbarSlider)
+		}
+		transparencyView.addSubview(slider)
+		slider.translatesAutoresizingMaskIntoConstraints = false
+		slider.leadingAnchor.constraint(equalTo: transparencyView.leadingAnchor, constant: 40).isActive = true
+		slider.trailingAnchor.constraint(equalTo: transparencyView.trailingAnchor, constant: -20).isActive = true
+		slider.centerYAnchor.constraint(equalTo: transparencyView.centerYAnchor).isActive = true
+		transparencyItem.view = transparencyView
+
 		statusMenuItemShowOnAllDesktops = menuItem("Show on All Desktops") { _ in
 			self.showOnAllDesktops = !self.showOnAllDesktops
 		}
@@ -149,6 +165,12 @@ extension AppDelegate: NSMenuDelegate {
 			NSMenuItem.separator(),
 
 			statusMenuItemShowOnAllDesktops,
+
+			NSMenuItem.separator(),
+
+			takeScreenshotItem,
+			NSMenuItem(title: "Transparency", action: nil, keyEquivalent: ""),
+			transparencyItem,
 
 			NSMenuItem.separator(),
 

--- a/Touch Bar Simulator/AppDelegate.swift
+++ b/Touch Bar Simulator/AppDelegate.swift
@@ -5,16 +5,25 @@ private let defaults = UserDefaults.standard
 
 final class AppDelegate: NSObject, NSApplicationDelegate {
 	lazy var window = with(TouchBarWindow()) {
-		$0.delegate = self
 		$0.alphaValue = CGFloat(defaults.double(forKey: "windowTransparency"))
 	}
 
 	lazy var toolbarView: NSView = self.window.toolbarView!
 
+	lazy var statusItem = with(NSStatusBar.system.statusItem(withLength: NSStatusItem.squareLength)) {
+		$0.menu = statusMenu
+		$0.button!.image = NSImage(named: "AppIcon") // TODO: Add proper icon
+		$0.button!.toolTip = NSLocalizedString("Right or option-click for menu", comment: "Status bar item tooltip")
+	}
+	lazy var statusMenu = with(NSMenu()) {
+		$0.delegate = self
+	}
+
 	func applicationWillFinishLaunching(_ notification: Notification) {
 		defaults.register(defaults: [
 			"NSApplicationCrashOnExceptions": true,
-			"windowTransparency": 0.75
+			"windowTransparency": 0.75,
+			"windowDocking": TouchBarWindow.Docking.floating.rawValue
 		])
 	}
 
@@ -46,6 +55,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 		window.setFrameAutosaveName(Constants.windowAutosaveName)
 
 		window.orderFront(nil)
+
+		_ = statusItem
+
+		docking = defaults.string(forKey: "windowDocking").flatMap { TouchBarWindow.Docking(rawValue: $0) } ?? .floating
+		showOnAllDesktops = defaults.bool(forKey: "showOnAllDesktops")
 	}
 
 	func makeScreenshotButton() -> NSButton {
@@ -82,12 +96,126 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
 	@objc
 	func toggleView(_ pboard: NSPasteboard, userData: String, error: NSErrorPointer) {
+		toggleView()
+	}
+
+	func toggleView() {
 		window.setIsVisible(!window.isVisible)
+	}
+
+	var docking: TouchBarWindow.Docking = .floating {
+		didSet {
+			defaults.setValue(docking.rawValue, forKey: "windowDocking")
+
+			statusMenuDockingItems.forEach { $0.state = .off }
+
+			let onItem: NSMenuItem
+			switch docking {
+			case .floating:
+				onItem = statusMenuDockingItemFloating
+			case .dockedToTop:
+				onItem = statusMenuDockingItemDockedToTop
+			case .dockedToBottom:
+				onItem = statusMenuDockingItemDockedToBottom
+			}
+			onItem.state = .on
+
+			window.docking = docking
+		}
+	}
+
+	var showOnAllDesktops: Bool = false {
+		didSet {
+			defaults.setValue(showOnAllDesktops, forKey: "showOnAllDesktops")
+			statusMenuItemShowOnAllDesktops.state = showOnAllDesktops ? .on : .off
+			window.showOnAllDesktops = showOnAllDesktops
+		}
+	}
+
+	@objc
+	func setFloating() {
+		docking = .floating
+	}
+	@objc
+	func setDockedToTop() {
+		docking = .dockedToTop
+	}
+	@objc
+	func setDockedToBottom() {
+		docking = .dockedToBottom
+	}
+
+	@objc
+	func toggleShowOnAllDesktops() {
+		showOnAllDesktops = !showOnAllDesktops
 	}
 }
 
-extension AppDelegate: NSWindowDelegate {
-	func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
-		return true
+private func leftMouseIsDown() -> Bool {
+	return NSApp.currentEvent?.type == .leftMouseDown
+}
+private func optionKeyIsDown() -> Bool {
+	return NSApp.currentEvent?.modifierFlags.contains(.option) ?? false
+}
+
+private func statusItemShouldShowMenu() -> Bool {
+	return !leftMouseIsDown() || optionKeyIsDown()
+}
+
+private var statusMenuDockingItemFloating = NSMenuItem(title: NSLocalizedString("Floating", comment: "Status menu Docking item"), action: #selector(AppDelegate.setFloating), keyEquivalent: "")
+private var statusMenuDockingItemDockedToTop = NSMenuItem(title: NSLocalizedString("Docked to Top", comment: "Status menu Docking item"), action: #selector(AppDelegate.setDockedToTop), keyEquivalent: "")
+private var statusMenuDockingItemDockedToBottom = NSMenuItem(title: NSLocalizedString("Docked to Bottom", comment: "Status menu Docking item"), action: #selector(AppDelegate.setDockedToBottom), keyEquivalent: "")
+private var statusMenuDockingItems: [NSMenuItem] = [
+	statusMenuDockingItemFloating,
+	statusMenuDockingItemDockedToTop,
+	statusMenuDockingItemDockedToBottom
+].map { $0.indentationLevel = 1; return $0 }
+
+private var statusMenuItemShowOnAllDesktops = NSMenuItem(title: NSLocalizedString("Show on All Desktops", comment: "Status menu item"), action: #selector(AppDelegate.toggleShowOnAllDesktops), keyEquivalent: "")
+
+private var statusMenuOptionItems: [NSMenuItem] = [
+
+	NSMenuItem(title: NSLocalizedString("Docking", comment: "Status menu label item"), action: nil, keyEquivalent: ""),
+	statusMenuDockingItemFloating,
+	statusMenuDockingItemDockedToTop,
+	statusMenuDockingItemDockedToBottom,
+
+	NSMenuItem.separator(),
+
+	statusMenuItemShowOnAllDesktops,
+
+	NSMenuItem.separator(),
+
+	NSMenuItem(title: NSLocalizedString("Quit Touch Bar Simulator", comment: "Status menu item"), action: #selector(NSApplication.terminate(_:)), keyEquivalent: "")
+
+]
+
+extension AppDelegate: NSMenuDelegate {
+	func menuNeedsUpdate(_ menu: NSMenu) {
+		guard statusItemShouldShowMenu() else {
+			menu.removeAllItems()
+			return
+		}
+		guard menu.numberOfItems != statusMenuOptionItems.count else {
+			return
+		}
+		menu.removeAllItems()
+		if #available(macOS 10.14, *) {
+			menu.items = statusMenuOptionItems
+		} else {
+			statusMenuOptionItems.forEach { menu.addItem($0) }
+		}
+	}
+
+	func menuWillOpen(_ menu: NSMenu) {
+		guard !statusItemShouldShowMenu() else {
+			return
+		}
+		statusItemButtonClicked()
+	}
+
+	func statusItemButtonClicked() {
+		toggleView()
+		if window.isVisible { window.orderFront(nil) }
 	}
 }

--- a/Touch Bar Simulator/AppDelegate.swift
+++ b/Touch Bar Simulator/AppDelegate.swift
@@ -108,7 +108,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
 extension AppDelegate: NSMenuDelegate {
 	func createMenuItems() {
-		func menuItem(_ title: String, keyEquivalent: String = "", action: @escaping NSMenuItem.ActionClosure) -> NSMenuItem {
+		func menuItem(_ title: String, keyEquivalent: String = "", action: @escaping TargetActionSender.ActionClosure) -> NSMenuItem {
 			let item = NSMenuItem(title: title, action: nil, keyEquivalent: keyEquivalent)
 			item.onAction = action
 			return item

--- a/Touch Bar Simulator/AppDelegate.swift
+++ b/Touch Bar Simulator/AppDelegate.swift
@@ -24,9 +24,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 		NSApp.servicesProvider = self
 		_ = SUUpdater()
 		_ = statusItem
-
-		docking = defaults[.windowDocking]
-		showOnAllDesktops = defaults[.showOnAllDesktops]
 	}
 
 	@objc
@@ -44,20 +41,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 		window.setIsVisible(!window.isVisible)
 	}
 
-	var docking: TouchBarWindow.Docking = .floating {
-		didSet {
-			defaults[.windowDocking] = docking
-			window.docking = docking
-		}
-	}
-
-	var showOnAllDesktops: Bool = false {
-		didSet {
-			defaults[.showOnAllDesktops] = showOnAllDesktops
-			window.showOnAllDesktops = showOnAllDesktops
-		}
-	}
-
 }
 
 extension AppDelegate: NSMenuDelegate {
@@ -70,15 +53,9 @@ extension AppDelegate: NSMenuDelegate {
 
 		menu.addItem(NSMenuItem(title: "Docking", action: nil, keyEquivalent: ""))
 		var statusMenuDockingItems: [NSMenuItem] = []
-		statusMenuDockingItems.append(NSMenuItem.menuItem("Floating", isOn: docking == .floating) { _ in
-			self.docking = .floating
-		})
-		statusMenuDockingItems.append(NSMenuItem.menuItem("Docked to Top", isOn: docking == .dockedToTop) { _ in
-			self.docking = .dockedToTop
-		})
-		statusMenuDockingItems.append(NSMenuItem.menuItem("Docked to Bottom", isOn: docking == .dockedToBottom) { _ in
-			self.docking = .dockedToBottom
-		})
+		statusMenuDockingItems.append(NSMenuItem.menuItem("Floating").bindActivation(to: .windowDocking, value: .floating))
+		statusMenuDockingItems.append(NSMenuItem.menuItem("Docked to Top").bindActivation(to: .windowDocking, value: .dockedToTop))
+		statusMenuDockingItems.append(NSMenuItem.menuItem("Docked to Bottom").bindActivation(to: .windowDocking, value: .dockedToBottom))
 		for item in statusMenuDockingItems {
 			item.indentationLevel = 1
 		}
@@ -107,10 +84,7 @@ extension AppDelegate: NSMenuDelegate {
 
 		menu.addItem(NSMenuItem.separator())
 
-		let showOnAllDesktopsItem = NSMenuItem.menuItem("Show on All Desktops", isOn: defaults[.showOnAllDesktops]) { _ in
-			self.showOnAllDesktops = !self.showOnAllDesktops
-		}
-		menu.addItem(showOnAllDesktopsItem)
+		menu.addItem(NSMenuItem.menuItem("Show on All Desktops").bindToggle(to: .showOnAllDesktops))
 
 		menu.addItem(NSMenuItem.separator())
 

--- a/Touch Bar Simulator/AppDelegate.swift
+++ b/Touch Bar Simulator/AppDelegate.swift
@@ -162,15 +162,16 @@ extension AppDelegate: NSMenuDelegate {
 			statusMenuItemDockedToTop,
 			statusMenuItemDockedToBottom,
 
-			NSMenuItem.separator(),
-
-			statusMenuItemShowOnAllDesktops,
+			NSMenuItem(title: "Transparency", action: nil, keyEquivalent: ""),
+			transparencyItem,
 
 			NSMenuItem.separator(),
 
 			takeScreenshotItem,
-			NSMenuItem(title: "Transparency", action: nil, keyEquivalent: ""),
-			transparencyItem,
+
+			NSMenuItem.separator(),
+
+			statusMenuItemShowOnAllDesktops,
 
 			NSMenuItem.separator(),
 

--- a/Touch Bar Simulator/AppDelegate.swift
+++ b/Touch Bar Simulator/AppDelegate.swift
@@ -8,8 +8,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 		$0.alphaValue = CGFloat(defaults.double(forKey: "windowTransparency"))
 	}
 
-	lazy var toolbarView: NSView = self.window.toolbarView!
-
 	lazy var statusItem = with(NSStatusBar.system.statusItem(withLength: NSStatusItem.squareLength)) {
 		$0.menu = statusMenu
 		$0.button!.image = NSImage(named: "AppIcon") // TODO: Add proper icon
@@ -41,11 +39,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 		touchBarView.frame = touchBarView.frame.centered(in: view.bounds)
 		view.addSubview(touchBarView)
 
-		toolbarView.addSubviews(
-			makeScreenshotButton(),
-			makeTransparencySlider()
-		)
-
 		window.center()
 		var origin = window.frame.origin
 		origin.y = 100
@@ -62,36 +55,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 		showOnAllDesktops = defaults.bool(forKey: "showOnAllDesktops")
 	}
 
-	func makeScreenshotButton() -> NSButton {
-		let button = NSButton()
-		button.image = #imageLiteral(resourceName: "ScreenshotButton")
-		button.imageScaling = .scaleProportionallyDown
-		button.isBordered = false
-		button.bezelStyle = .shadowlessSquare
-		button.frame = CGRect(x: toolbarView.frame.width - 19, y: 4, width: 16, height: 11)
-		button.action = #selector(captureScreenshot)
-		return button
-	}
-
-	func makeTransparencySlider() -> ToolbarSlider {
-		let slider = ToolbarSlider()
-		slider.frame = CGRect(x: toolbarView.frame.width - 150, y: 4, width: 120, height: 11)
-		slider.action = #selector(setTransparency)
-		slider.minValue = 0.5
-		slider.doubleValue = defaults.double(forKey: "windowTransparency")
-		return slider
-	}
-
 	@objc
 	func captureScreenshot() {
 		let KEY_6: CGKeyCode = 0x58
 		pressKey(keyCode: KEY_6, flags: [.maskShift, .maskCommand])
-	}
-
-	@objc
-	func setTransparency(sender: ToolbarSlider) {
-		window.alphaValue = CGFloat(sender.doubleValue)
-		defaults.set(sender.doubleValue, forKey: "windowTransparency")
 	}
 
 	@objc

--- a/Touch Bar Simulator/AppDelegate.swift
+++ b/Touch Bar Simulator/AppDelegate.swift
@@ -11,7 +11,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 	lazy var statusItem = with(NSStatusBar.system.statusItem(withLength: NSStatusItem.squareLength)) {
 		$0.menu = with(NSMenu()) { $0.delegate = self }
 		$0.button!.image = NSImage(named: "AppIcon") // TODO: Add proper icon
-		$0.button!.toolTip = "Right or option-click for menu"
+		$0.button!.toolTip = "Right-click or option-click for menu"
 	}
 
 	func applicationWillFinishLaunching(_ notification: Notification) {

--- a/Touch Bar Simulator/AppDelegate.swift
+++ b/Touch Bar Simulator/AppDelegate.swift
@@ -99,23 +99,49 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 		}
 	}
 
-	@objc
-	func setFloating() {
-		docking = .floating
+	private lazy var statusMenuDockingItemFloating = with(NSMenuItem(title: "Floating", action: nil, keyEquivalent: "")) {
+		$0.onAction = { _ in
+			self.docking = .floating
+		}
 	}
-	@objc
-	func setDockedToTop() {
-		docking = .dockedToTop
+	private lazy var statusMenuDockingItemDockedToTop = with(NSMenuItem(title: "Docked to Top", action: nil, keyEquivalent: "")) {
+		$0.onAction = { _ in
+			self.docking = .dockedToTop
+		}
 	}
-	@objc
-	func setDockedToBottom() {
-		docking = .dockedToBottom
+	private lazy var statusMenuDockingItemDockedToBottom = with(NSMenuItem(title: "Docked to Bottom", action: nil, keyEquivalent: "")) {
+		$0.onAction = { _ in
+			self.docking = .dockedToBottom
+		}
+	}
+	private lazy var statusMenuDockingItems: [NSMenuItem] = [
+		statusMenuDockingItemFloating,
+		statusMenuDockingItemDockedToTop,
+		statusMenuDockingItemDockedToBottom
+	].map { $0.indentationLevel = 1; return $0 }
+
+	private lazy var statusMenuItemShowOnAllDesktops = with(NSMenuItem(title: "Show on All Desktops", action: nil, keyEquivalent: "")) {
+		$0.onAction = { _ in
+			self.showOnAllDesktops = !self.showOnAllDesktops
+		}
 	}
 
-	@objc
-	func toggleShowOnAllDesktops() {
-		showOnAllDesktops = !showOnAllDesktops
-	}
+	private lazy var statusMenuOptionItems: [NSMenuItem] = [
+
+		NSMenuItem(title: "Docking", action: nil, keyEquivalent: ""),
+		statusMenuDockingItemFloating,
+		statusMenuDockingItemDockedToTop,
+		statusMenuDockingItemDockedToBottom,
+
+		NSMenuItem.separator(),
+
+		statusMenuItemShowOnAllDesktops,
+
+		NSMenuItem.separator(),
+
+		NSMenuItem(title: "Quit Touch Bar Simulator", action: #selector(NSApplication.terminate(_:)), keyEquivalent: "")
+
+	]
 }
 
 private func leftMouseIsDown() -> Bool {
@@ -128,34 +154,6 @@ private func optionKeyIsDown() -> Bool {
 private func statusItemShouldShowMenu() -> Bool {
 	return !leftMouseIsDown() || optionKeyIsDown()
 }
-
-private var statusMenuDockingItemFloating = NSMenuItem(title: "Floating", action: #selector(AppDelegate.setFloating), keyEquivalent: "")
-private var statusMenuDockingItemDockedToTop = NSMenuItem(title: "Docked to Top", action: #selector(AppDelegate.setDockedToTop), keyEquivalent: "")
-private var statusMenuDockingItemDockedToBottom = NSMenuItem(title: "Docked to Bottom", action: #selector(AppDelegate.setDockedToBottom), keyEquivalent: "")
-private var statusMenuDockingItems: [NSMenuItem] = [
-	statusMenuDockingItemFloating,
-	statusMenuDockingItemDockedToTop,
-	statusMenuDockingItemDockedToBottom
-].map { $0.indentationLevel = 1; return $0 }
-
-private var statusMenuItemShowOnAllDesktops = NSMenuItem(title: "Show on All Desktops", action: #selector(AppDelegate.toggleShowOnAllDesktops), keyEquivalent: "")
-
-private var statusMenuOptionItems: [NSMenuItem] = [
-
-	NSMenuItem(title: "Docking", action: nil, keyEquivalent: ""),
-	statusMenuDockingItemFloating,
-	statusMenuDockingItemDockedToTop,
-	statusMenuDockingItemDockedToBottom,
-
-	NSMenuItem.separator(),
-
-	statusMenuItemShowOnAllDesktops,
-
-	NSMenuItem.separator(),
-
-	NSMenuItem(title: "Quit Touch Bar Simulator", action: #selector(NSApplication.terminate(_:)), keyEquivalent: "")
-
-]
 
 extension AppDelegate: NSMenuDelegate {
 	func menuNeedsUpdate(_ menu: NSMenu) {

--- a/Touch Bar Simulator/AppDelegate.swift
+++ b/Touch Bar Simulator/AppDelegate.swift
@@ -53,9 +53,9 @@ extension AppDelegate: NSMenuDelegate {
 
 		menu.addItem(NSMenuItem(title: "Docking", action: nil, keyEquivalent: ""))
 		var statusMenuDockingItems: [NSMenuItem] = []
-		statusMenuDockingItems.append(NSMenuItem("Floating").streamChoice(to: .windowDocking, value: .floating))
-		statusMenuDockingItems.append(NSMenuItem("Docked to Top").streamChoice(to: .windowDocking, value: .dockedToTop))
-		statusMenuDockingItems.append(NSMenuItem("Docked to Bottom").streamChoice(to: .windowDocking, value: .dockedToBottom))
+		statusMenuDockingItems.append(NSMenuItem("Floating").bindChecked(to: .windowDocking, value: .floating))
+		statusMenuDockingItems.append(NSMenuItem("Docked to Top").bindChecked(to: .windowDocking, value: .dockedToTop))
+		statusMenuDockingItems.append(NSMenuItem("Docked to Bottom").bindChecked(to: .windowDocking, value: .dockedToBottom))
 		for item in statusMenuDockingItems {
 			item.indentationLevel = 1
 		}
@@ -64,7 +64,7 @@ extension AppDelegate: NSMenuDelegate {
 		menu.addItem(NSMenuItem(title: "Transparency", action: nil, keyEquivalent: ""))
 		let transparencyItem = NSMenuItem("Transparency")
 		let transparencyView = NSView(frame: CGRect(origin: .zero, size: CGSize(width: 200, height: 20)))
-		let slider = MenubarSlider().alwaysRedisplayOnValueChanged().streamDoubleValue(to: .windowTransparency)
+		let slider = MenubarSlider().alwaysRedisplayOnValueChanged().bindDoubleValue(to: .windowTransparency)
 		slider.frame = CGRect(x: 20, y: 4, width: 180, height: 11)
 		slider.minValue = 0.5
 		transparencyView.addSubview(slider)
@@ -83,7 +83,7 @@ extension AppDelegate: NSMenuDelegate {
 
 		menu.addItem(NSMenuItem.separator())
 
-		menu.addItem(NSMenuItem("Show on All Desktops").streamState(to: .showOnAllDesktops))
+		menu.addItem(NSMenuItem("Show on All Desktops").bindState(to: .showOnAllDesktops))
 
 		menu.addItem(NSMenuItem.separator())
 

--- a/Touch Bar Simulator/AppDelegate.swift
+++ b/Touch Bar Simulator/AppDelegate.swift
@@ -69,8 +69,8 @@ extension AppDelegate: NSMenuDelegate {
 		slider.minValue = 0.5
 		transparencyView.addSubview(slider)
 		slider.translatesAutoresizingMaskIntoConstraints = false
-		slider.leadingAnchor.constraint(equalTo: transparencyView.leadingAnchor, constant: 33).isActive = true
-		slider.trailingAnchor.constraint(equalTo: transparencyView.trailingAnchor, constant: -18).isActive = true
+		slider.leadingAnchor.constraint(equalTo: transparencyView.leadingAnchor, constant: 24).isActive = true
+		slider.trailingAnchor.constraint(equalTo: transparencyView.trailingAnchor, constant: -9).isActive = true
 		slider.centerYAnchor.constraint(equalTo: transparencyView.centerYAnchor).isActive = true
 		transparencyItem.view = transparencyView
 		menu.addItem(transparencyItem)

--- a/Touch Bar Simulator/AppDelegate.swift
+++ b/Touch Bar Simulator/AppDelegate.swift
@@ -1,27 +1,24 @@
 import Cocoa
 import Sparkle
-
-private let defaults = UserDefaults.standard
+import Defaults
 
 final class AppDelegate: NSObject, NSApplicationDelegate {
 	lazy var window = with(TouchBarWindow()) {
-		$0.alphaValue = CGFloat(defaults.double(forKey: "windowTransparency"))
+		$0.alphaValue = CGFloat(defaults[.windowTransparency])
 	}
 
 	lazy var statusItem = with(NSStatusBar.system.statusItem(withLength: NSStatusItem.squareLength)) {
 		$0.menu = statusMenu
 		$0.button!.image = NSImage(named: "AppIcon") // TODO: Add proper icon
-		$0.button!.toolTip = "Right or option-click for menu";
+		$0.button!.toolTip = "Right or option-click for menu"
 	}
 	lazy var statusMenu = with(NSMenu()) {
 		$0.delegate = self
 	}
 
 	func applicationWillFinishLaunching(_ notification: Notification) {
-		defaults.register(defaults: [
-			"NSApplicationCrashOnExceptions": true,
-			"windowTransparency": 0.75,
-			"windowDocking": TouchBarWindow.Docking.floating.rawValue
+		UserDefaults.standard.register(defaults: [
+			"NSApplicationCrashOnExceptions": true
 		])
 	}
 
@@ -51,8 +48,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
 		_ = statusItem
 
-		docking = defaults.string(forKey: "windowDocking").flatMap { TouchBarWindow.Docking(rawValue: $0) } ?? .floating
-		showOnAllDesktops = defaults.bool(forKey: "showOnAllDesktops")
+		docking = defaults[.windowDocking]
+		showOnAllDesktops = defaults[.showOnAllDesktops]
 	}
 
 	@objc
@@ -72,7 +69,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
 	var docking: TouchBarWindow.Docking = .floating {
 		didSet {
-			defaults.setValue(docking.rawValue, forKey: "windowDocking")
+			defaults[.windowDocking] = docking
 
 			statusMenuDockingItems.forEach { $0.state = .off }
 
@@ -93,7 +90,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
 	var showOnAllDesktops: Bool = false {
 		didSet {
-			defaults.setValue(showOnAllDesktops, forKey: "showOnAllDesktops")
+			defaults[.showOnAllDesktops] = showOnAllDesktops
 			statusMenuItemShowOnAllDesktops.state = showOnAllDesktops ? .on : .off
 			window.showOnAllDesktops = showOnAllDesktops
 		}

--- a/Touch Bar Simulator/AppDelegate.swift
+++ b/Touch Bar Simulator/AppDelegate.swift
@@ -141,15 +141,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 	]
 }
 
-private func leftMouseIsDown() -> Bool {
-	return NSApp.currentEvent?.type == .leftMouseDown
-}
-private func optionKeyIsDown() -> Bool {
-	return NSApp.currentEvent?.modifierFlags.contains(.option) ?? false
-}
-
 private func statusItemShouldShowMenu() -> Bool {
-	return !leftMouseIsDown() || optionKeyIsDown()
+	return !NSApp.leftMouseIsDown() || NSApp.optionKeyIsDown()
 }
 
 extension AppDelegate: NSMenuDelegate {

--- a/Touch Bar Simulator/AppDelegate.swift
+++ b/Touch Bar Simulator/AppDelegate.swift
@@ -65,12 +65,19 @@ extension AppDelegate: NSMenuDelegate {
 		let transparencyItem = NSMenuItem("Transparency")
 		let transparencyView = NSView(frame: CGRect(origin: .zero, size: CGSize(width: 200, height: 20)))
 		let slider = MenubarSlider()
-		slider.frame = CGRect(x: 20, y: 4, width: 180, height: 11)
 		slider.onAction = { sender in
-			defaults[.windowTransparency] = sender.doubleValue
+			// Redisplaying the slider prevents shadow artifacts that result
+			// from moving a knob that draws a shadow
+			// However, only do so if its value has changed, because if a
+			// redisplay is attempted without a change, then the slider draws
+			// itself brighter for some reason
+			if (defaults[.windowTransparency] - sender.doubleValue) != 0 {
+				sender.needsDisplay = true
+			}
 		}
+		_ = slider.streamDoubleValue(to: .windowTransparency)
+		slider.frame = CGRect(x: 20, y: 4, width: 180, height: 11)
 		slider.minValue = 0.5
-		slider.doubleValue = defaults[.windowTransparency]
 		transparencyView.addSubview(slider)
 		slider.translatesAutoresizingMaskIntoConstraints = false
 		slider.leadingAnchor.constraint(equalTo: transparencyView.leadingAnchor, constant: 33).isActive = true

--- a/Touch Bar Simulator/Constants.swift
+++ b/Touch Bar Simulator/Constants.swift
@@ -9,4 +9,5 @@ extension Defaults.Keys {
 	static let windowTransparency = Key<Double>("windowTransparency", default: 0.75)
 	static let windowDocking = Key<TouchBarWindow.Docking>("windowDocking", default: .floating)
 	static let showOnAllDesktops = Key<Bool>("showOnAllDesktops", default: false)
+	static let lastFloatingPos = OptionalKey<CGPoint>("lastFloatingPos")
 }

--- a/Touch Bar Simulator/Constants.swift
+++ b/Touch Bar Simulator/Constants.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+struct Constants {
+	static let windowAutosaveName = "TouchBarWindow"
+}

--- a/Touch Bar Simulator/Constants.swift
+++ b/Touch Bar Simulator/Constants.swift
@@ -1,5 +1,12 @@
 import Foundation
+import Defaults
 
 struct Constants {
 	static let windowAutosaveName = "TouchBarWindow"
+}
+
+extension Defaults.Keys {
+	static let windowTransparency = Key<Double>("windowTransparency", default: 0.75)
+	static let windowDocking = Key<TouchBarWindow.Docking>("windowDocking", default: .floating)
+	static let showOnAllDesktops = Key<Bool>("showOnAllDesktops", default: false)
 }

--- a/Touch Bar Simulator/Constants.swift
+++ b/Touch Bar Simulator/Constants.swift
@@ -9,5 +9,5 @@ extension Defaults.Keys {
 	static let windowTransparency = Key<Double>("windowTransparency", default: 0.75)
 	static let windowDocking = Key<TouchBarWindow.Docking>("windowDocking", default: .floating)
 	static let showOnAllDesktops = Key<Bool>("showOnAllDesktops", default: false)
-	static let lastFloatingPos = OptionalKey<CGPoint>("lastFloatingPos")
+	static let lastFloatingPosition = OptionalKey<CGPoint>("lastFloatingPosition")
 }

--- a/Touch Bar Simulator/Glue.swift
+++ b/Touch Bar Simulator/Glue.swift
@@ -2,23 +2,44 @@ import Foundation
 import Defaults
 
 extension NSMenuItem {
+	/**
+	Adds an action to this menu item that toggles the value of `key` in the
+	defaults system, and initializes this item's state to the current value of
+	`key`.
+	
+	```
+	let menuItem = NSMenuItem(title: "Invert Colors").bindToggle(to: .invertColors)
+	```
+	*/
 	func bindToggle(to key: Defaults.Key<Bool>) -> NSMenuItem {
 		let action = self.onAction
 		self.onAction = { sender in
-			defaults[key] = !defaults[key]
+			defaults[key].toggle()
 			action?(sender)
 		}
-		self.state = defaults[key] ? .on : .off
+		self.isChecked = defaults[key]
 		return self
 	}
 
-	func bindActivation<Value: Equatable>(to key: Defaults.Key<Value>, value: Value) -> NSMenuItem {
+	/**
+	Adds an action to this menu item that sets the value of `key` in the
+	defaults system to `value`, and initializes this item's state based on
+	whether the current value of `key` matches `value`.
+	
+	```
+	enum BillingType {
+		case paper, electronic, duck
+	}
+	let menuItem = NSMenuItem(title: "Duck").bindChoice(to: .billingType, value: .duck)
+	```
+	*/
+	func bindChoice<Value: Equatable>(to key: Defaults.Key<Value>, value: Value) -> NSMenuItem {
 		let action = self.onAction
 		self.onAction = { sender in
 			defaults[key] = value
 			action?(sender)
 		}
-		self.state = defaults[key] == value ? .on : .off
+		self.isChecked = (defaults[key] == value)
 		return self
 	}
 }

--- a/Touch Bar Simulator/Glue.swift
+++ b/Touch Bar Simulator/Glue.swift
@@ -1,0 +1,28 @@
+import Foundation
+import Defaults
+
+extension NSMenuItem {
+	func bindToggle(to key: Defaults.Key<Bool>) -> NSMenuItem {
+		let action = self.onAction
+		self.onAction = { sender in
+			defaults[key] = !defaults[key]
+			if let action = action {
+				action(sender)
+			}
+		}
+		self.state = defaults[key] ? .on : .off
+		return self
+	}
+
+	func bindActivation<Value: Equatable>(to key: Defaults.Key<Value>, value: Value) -> NSMenuItem {
+		let action = self.onAction
+		self.onAction = { sender in
+			defaults[key] = value
+			if let action = action {
+				action(sender)
+			}
+		}
+		self.state = defaults[key] == value ? .on : .off
+		return self
+	}
+}

--- a/Touch Bar Simulator/Glue.swift
+++ b/Touch Bar Simulator/Glue.swift
@@ -6,7 +6,7 @@ extension NSMenuItem {
 	Adds an action to this menu item that toggles the value of `key` in the
 	defaults system, and initializes this item's state to the current value of
 	`key`.
-	
+
 	```
 	let menuItem = NSMenuItem(title: "Invert Colors").streamState(to: .invertColors)
 	```
@@ -25,7 +25,7 @@ extension NSMenuItem {
 	Adds an action to this menu item that sets the value of `key` in the
 	defaults system to `value`, and initializes this item's state based on
 	whether the current value of `key` matches `value`.
-	
+
 	```
 	enum BillingType {
 		case paper, electronic, duck
@@ -40,6 +40,27 @@ extension NSMenuItem {
 			defaults[key] = value
 		}
 		self.isChecked = (defaults[key] == value)
+		return self
+	}
+}
+
+extension NSSlider {
+	/**
+	Adds an action to this slider that sets the value of `key` in the defaults
+	system to the slider's `doubleValue`, and initializes its value to the
+	current value of `key`.
+
+	```
+	let slider = NSSlider().streamDoubleValue(to: .transparency)
+	```
+	*/
+	func streamDoubleValue(to key: Defaults.Key<Double>) -> Self {
+		let action = self.onAction
+		self.onAction = { sender in
+			action?(sender)
+			defaults[key] = sender.doubleValue
+		}
+		self.doubleValue = defaults[key]
 		return self
 	}
 }

--- a/Touch Bar Simulator/Glue.swift
+++ b/Touch Bar Simulator/Glue.swift
@@ -12,9 +12,7 @@ extension NSMenuItem {
 	```
 	*/
 	func streamState(to key: Defaults.Key<Bool>) -> Self {
-		let action = self.onAction
-		self.onAction = { sender in
-			action?(sender)
+		self.addAction { _ in
 			defaults[key].toggle()
 		}
 		self.isChecked = defaults[key]
@@ -34,9 +32,7 @@ extension NSMenuItem {
 	```
 	*/
 	func streamChoice<Value: Equatable>(to key: Defaults.Key<Value>, value: Value) -> Self {
-		let action = self.onAction
-		self.onAction = { sender in
-			action?(sender)
+		self.addAction { _ in
 			defaults[key] = value
 		}
 		self.isChecked = (defaults[key] == value)
@@ -55,9 +51,7 @@ extension NSSlider {
 	```
 	*/
 	func streamDoubleValue(to key: Defaults.Key<Double>) -> Self {
-		let action = self.onAction
-		self.onAction = { sender in
-			action?(sender)
+		self.addAction { sender in
 			defaults[key] = sender.doubleValue
 		}
 		self.doubleValue = defaults[key]

--- a/Touch Bar Simulator/Glue.swift
+++ b/Touch Bar Simulator/Glue.swift
@@ -6,9 +6,7 @@ extension NSMenuItem {
 		let action = self.onAction
 		self.onAction = { sender in
 			defaults[key] = !defaults[key]
-			if let action = action {
-				action(sender)
-			}
+			action?(sender)
 		}
 		self.state = defaults[key] ? .on : .off
 		return self
@@ -18,9 +16,7 @@ extension NSMenuItem {
 		let action = self.onAction
 		self.onAction = { sender in
 			defaults[key] = value
-			if let action = action {
-				action(sender)
-			}
+			action?(sender)
 		}
 		self.state = defaults[key] == value ? .on : .off
 		return self

--- a/Touch Bar Simulator/Glue.swift
+++ b/Touch Bar Simulator/Glue.swift
@@ -8,14 +8,14 @@ extension NSMenuItem {
 	`key`.
 	
 	```
-	let menuItem = NSMenuItem(title: "Invert Colors").bindToggle(to: .invertColors)
+	let menuItem = NSMenuItem(title: "Invert Colors").streamState(to: .invertColors)
 	```
 	*/
-	func bindToggle(to key: Defaults.Key<Bool>) -> NSMenuItem {
+	func streamState(to key: Defaults.Key<Bool>) -> Self {
 		let action = self.onAction
 		self.onAction = { sender in
-			defaults[key].toggle()
 			action?(sender)
+			defaults[key].toggle()
 		}
 		self.isChecked = defaults[key]
 		return self
@@ -30,14 +30,14 @@ extension NSMenuItem {
 	enum BillingType {
 		case paper, electronic, duck
 	}
-	let menuItem = NSMenuItem(title: "Duck").bindChoice(to: .billingType, value: .duck)
+	let menuItem = NSMenuItem(title: "Duck").streamChoice(to: .billingType, value: .duck)
 	```
 	*/
-	func bindChoice<Value: Equatable>(to key: Defaults.Key<Value>, value: Value) -> NSMenuItem {
+	func streamChoice<Value: Equatable>(to key: Defaults.Key<Value>, value: Value) -> Self {
 		let action = self.onAction
 		self.onAction = { sender in
-			defaults[key] = value
 			action?(sender)
+			defaults[key] = value
 		}
 		self.isChecked = (defaults[key] == value)
 		return self

--- a/Touch Bar Simulator/ToolbarSlider.swift
+++ b/Touch Bar Simulator/ToolbarSlider.swift
@@ -19,7 +19,13 @@ private final class ToolbarSliderCell: NSSliderCell {
 	}
 
 	override func drawKnob(_ knobRect: CGRect) {
-		let frame = knobRect.insetBy(dx: 0, dy: 6.5)
+		var frame = knobRect.insetBy(dx: 0, dy: 6.5)
+		if let shadow = self.shadow {
+			// Make room on either side of the view for the shadow to spill into,
+			// rather than clip on the edges
+			frame.origin.x *= ((self.barRect.width - shadow.shadowBlurRadius * 2) / self.barRect.width)
+			frame.origin.x += shadow.shadowBlurRadius
+		}
 
 		NSGraphicsContext.saveGraphicsState()
 
@@ -39,6 +45,19 @@ private final class ToolbarSliderCell: NSSliderCell {
 		path.stroke()
 
 		NSGraphicsContext.restoreGraphicsState()
+	}
+
+	private var barRect = CGRect.zero
+
+	override func drawBar(inside rect: CGRect, flipped: Bool) {
+		self.barRect = rect
+		// A knob shadow requires a small skew in the origin of the knob (see above),
+		// which causes the knob to not go all the way to the ends of the bar
+		// Fix this by shortening the bar
+		if let shadow = self.shadow {
+			self.barRect = self.barRect.insetBy(dx: shadow.shadowBlurRadius * 2, dy: 0)
+		}
+		super.drawBar(inside: self.barRect, flipped: flipped)
 	}
 }
 

--- a/Touch Bar Simulator/ToolbarSlider.swift
+++ b/Touch Bar Simulator/ToolbarSlider.swift
@@ -86,7 +86,7 @@ final class ToolbarSlider: NSSlider {
 		knobShadow.shadowOffset = CGSize(width: 0.8, height: -0.8)
 		knobShadow.shadowBlurRadius = 5
 
-		self.cell = ToolbarSliderCell(fillColor: NSColor.lightGray, borderColor: .black, shadow: knobShadow)
+		self.cell = ToolbarSliderCell(fillColor: .lightGray, borderColor: .black, shadow: knobShadow)
 	}
 
 	@available(*, unavailable)

--- a/Touch Bar Simulator/ToolbarSlider.swift
+++ b/Touch Bar Simulator/ToolbarSlider.swift
@@ -1,6 +1,6 @@
 import Cocoa
 
-private let knob: NSImage = {
+private func makeKnob(fillColor: NSColor, borderColor: NSColor) -> NSImage {
 	let frame = CGRect(x: 0, y: 0, width: 32, height: 32)
 
 	let image = NSImage(size: frame.size)
@@ -8,19 +8,31 @@ private let knob: NSImage = {
 
 	// Circle
 	let path = NSBezierPath(roundedRect: frame, xRadius: 4, yRadius: 12)
-	NSColor.lightGray.set()
+	fillColor.set()
 	path.fill()
 
 	// Border
-	NSColor.black.set()
+	borderColor.set()
 	path.lineWidth = 2
 	path.stroke()
 
 	image.unlockFocus()
 	return image
-}()
+}
 
 private final class ToolbarSliderCell: NSSliderCell {
+	var knob: NSImage
+
+	init(knob: NSImage) {
+		self.knob = knob
+		super.init()
+	}
+
+	@available(*, unavailable)
+	required init(coder: NSCoder) {
+		fatalError("init(coder:) has not been implemented")
+	}
+
 	override func drawKnob(_ knobRect: CGRect) {
 		knob.draw(in: knobRect.insetBy(dx: 0, dy: 6.5))
 	}
@@ -29,7 +41,19 @@ private final class ToolbarSliderCell: NSSliderCell {
 final class ToolbarSlider: NSSlider {
 	override init(frame: CGRect) {
 		super.init(frame: frame)
-		cell = ToolbarSliderCell()
+		cell = ToolbarSliderCell(knob: makeKnob(fillColor: .lightGray, borderColor: .black))
+	}
+
+	@available(*, unavailable)
+	required init?(coder: NSCoder) {
+		fatalError("init(coder:) has not been implemented")
+	}
+}
+
+final class MenubarSlider: NSSlider {
+	override init(frame: CGRect) {
+		super.init(frame: frame)
+		cell = ToolbarSliderCell(knob: makeKnob(fillColor: NSColor.controlTextColor.withAlphaComponent(1.0), borderColor: .systemGray))
 	}
 
 	@available(*, unavailable)

--- a/Touch Bar Simulator/ToolbarSlider.swift
+++ b/Touch Bar Simulator/ToolbarSlider.swift
@@ -1,30 +1,14 @@
 import Cocoa
 
-private func makeKnob(fillColor: NSColor, borderColor: NSColor) -> NSImage {
-	let frame = CGRect(x: 0, y: 0, width: 32, height: 32)
-
-	let image = NSImage(size: frame.size)
-	image.lockFocus()
-
-	// Circle
-	let path = NSBezierPath(roundedRect: frame, xRadius: 4, yRadius: 12)
-	fillColor.set()
-	path.fill()
-
-	// Border
-	borderColor.set()
-	path.lineWidth = 2
-	path.stroke()
-
-	image.unlockFocus()
-	return image
-}
-
 private final class ToolbarSliderCell: NSSliderCell {
-	var knob: NSImage
+	var fillColor: NSColor
+	var borderColor: NSColor
+	var shadow: NSShadow?
 
-	init(knob: NSImage) {
-		self.knob = knob
+	init(fillColor: NSColor, borderColor: NSColor, shadow: NSShadow? = nil) {
+		self.fillColor = fillColor
+		self.borderColor = borderColor
+		self.shadow = shadow
 		super.init()
 	}
 
@@ -34,14 +18,30 @@ private final class ToolbarSliderCell: NSSliderCell {
 	}
 
 	override func drawKnob(_ knobRect: CGRect) {
-		knob.draw(in: knobRect.insetBy(dx: 0, dy: 6.5))
+		let frame = knobRect.insetBy(dx: 0, dy: 6.5)
+
+		NSGraphicsContext.saveGraphicsState()
+
+		self.shadow?.set()
+
+		// Circle
+		let path = NSBezierPath(roundedRect: frame, xRadius: 4, yRadius: 12)
+		self.fillColor.set()
+		path.fill()
+
+		// Border
+		self.borderColor.set()
+		path.lineWidth = 2
+		path.stroke()
+
+		NSGraphicsContext.restoreGraphicsState()
 	}
 }
 
 final class ToolbarSlider: NSSlider {
 	override init(frame: CGRect) {
 		super.init(frame: frame)
-		cell = ToolbarSliderCell(knob: makeKnob(fillColor: .lightGray, borderColor: .black))
+		self.cell = ToolbarSliderCell(fillColor: .lightGray, borderColor: .black)
 	}
 
 	@available(*, unavailable)
@@ -53,7 +53,16 @@ final class ToolbarSlider: NSSlider {
 final class MenubarSlider: NSSlider {
 	override init(frame: CGRect) {
 		super.init(frame: frame)
-		cell = ToolbarSliderCell(knob: makeKnob(fillColor: NSColor.controlTextColor.withAlphaComponent(1.0), borderColor: .systemGray))
+
+		let accentColor = NSColor.controlAccentColor.withAlphaComponent(1.0)
+		let dimmedAccentColor = accentColor.blended(withFraction: 0.35, of: .black) ?? accentColor
+
+		let knobShadow = NSShadow()
+		knobShadow.shadowColor = NSColor.black.withAlphaComponent(0.6)
+		knobShadow.shadowOffset = CGSize(width: 0.8, height: -0.8)
+		knobShadow.shadowBlurRadius = 4
+
+		self.cell = ToolbarSliderCell(fillColor: dimmedAccentColor, borderColor: .clear, shadow: knobShadow)
 	}
 
 	@available(*, unavailable)

--- a/Touch Bar Simulator/TouchBarWindow.swift
+++ b/Touch Bar Simulator/TouchBarWindow.swift
@@ -1,6 +1,38 @@
 import Cocoa
 
+private let windowTitle = "Touch Bar Simulator"
+
 final class TouchBarWindow: NSPanel {
+	enum Docking: String {
+		case floating, dockedToTop, dockedToBottom
+	}
+
+	var docking: Docking = .floating {
+		didSet {
+			switch docking {
+			case .floating:
+				styleMask.insert(.titled)
+				title = windowTitle
+			case .dockedToTop:
+				styleMask.remove(.titled)
+				setFrameOrigin(NSPoint(x: NSScreen.main!.visibleFrame.width / 2 - frame.width / 2, y: NSScreen.main!.visibleFrame.maxY - frame.height))
+			case .dockedToBottom:
+				styleMask.remove(.titled)
+				setFrameOrigin(NSPoint(x: NSScreen.main!.visibleFrame.width / 2 - frame.width / 2, y: NSScreen.main!.visibleFrame.minY))
+			}
+		}
+	}
+
+	var showOnAllDesktops: Bool = false {
+		didSet {
+			if showOnAllDesktops {
+				collectionBehavior = .canJoinAllSpaces
+			} else {
+				collectionBehavior = .moveToActiveSpace
+			}
+		}
+	}
+
 	override var canBecomeMain: Bool {
 		return false
 	}
@@ -23,7 +55,7 @@ final class TouchBarWindow: NSPanel {
 		)
 
 		self._setPreventsActivation(true)
-		self.title = "Touch Bar Simulator"
+		self.title = windowTitle
 		self.isRestorable = true
 		self.hidesOnDeactivate = false
 		self.worksWhenModal = true

--- a/Touch Bar Simulator/TouchBarWindow.swift
+++ b/Touch Bar Simulator/TouchBarWindow.swift
@@ -28,6 +28,9 @@ final class TouchBarWindow: NSPanel {
 				styleMask.remove(.titled)
 				moveTo(x: .center, y: .bottom)
 			}
+
+			setIsVisible(true)
+			orderFront(nil)
 		}
 	}
 

--- a/Touch Bar Simulator/TouchBarWindow.swift
+++ b/Touch Bar Simulator/TouchBarWindow.swift
@@ -53,9 +53,9 @@ final class TouchBarWindow: NSPanel {
 		return button
 	}
 
-	func makeTransparencySlider(_ toolbarView: NSView) -> ToolbarSlider {
+	func makeTransparencySlider(_ parentView: NSView) -> ToolbarSlider {
 		let slider = ToolbarSlider()
-		slider.frame = CGRect(x: toolbarView.frame.width - 150, y: 4, width: 120, height: 11)
+		slider.frame = CGRect(x: parentView.frame.width - 150, y: 4, width: 120, height: 11)
 		slider.action = #selector(setTransparency)
 		slider.minValue = 0.5
 		slider.doubleValue = defaults[.windowTransparency]

--- a/Touch Bar Simulator/TouchBarWindow.swift
+++ b/Touch Bar Simulator/TouchBarWindow.swift
@@ -95,6 +95,8 @@ final class TouchBarWindow: NSPanel {
 		return false
 	}
 
+	private var defaultsObservations: [DefaultsObservation] = []
+
 	func setUp() {
 		let view = self.contentView!
 		view.wantsLayer = true
@@ -105,7 +107,15 @@ final class TouchBarWindow: NSPanel {
 		touchBarView.frame = touchBarView.frame.centered(in: view.bounds)
 		view.addSubview(touchBarView)
 
-		self.addTitlebar()
+		defaultsObservations.append(defaults.observe(.windowTransparency) { change in
+			self.alphaValue = CGFloat(change.newValue)
+		})
+		defaultsObservations.append(defaults.observe(.windowDocking) { change in
+			self.docking = change.newValue
+		})
+		defaultsObservations.append(defaults.observe(.showOnAllDesktops) { change in
+			self.showOnAllDesktops = change.newValue
+		})
 
 		self.center()
 		self.setFrameOrigin(CGPoint(x: self.frame.origin.x, y: 100))
@@ -116,7 +126,11 @@ final class TouchBarWindow: NSPanel {
 		self.orderFront(nil)
 	}
 
-	private var defaultsObservations: [DefaultsObservation] = []
+	deinit {
+		for observation in defaultsObservations {
+			observation.invalidate()
+		}
+	}
 
 	convenience init() {
 		self.init(
@@ -137,21 +151,5 @@ final class TouchBarWindow: NSPanel {
 		self.worksWhenModal = true
 		self.acceptsMouseMovedEvents = true
 		self.isMovableByWindowBackground = false
-
-		defaultsObservations.append(defaults.observe(.windowTransparency) { change in
-			self.alphaValue = CGFloat(change.newValue)
-		})
-		defaultsObservations.append(defaults.observe(.windowDocking) { change in
-			self.docking = change.newValue
-		})
-		defaultsObservations.append(defaults.observe(.showOnAllDesktops) { change in
-			self.showOnAllDesktops = change.newValue
-		})
-	}
-
-	deinit {
-		for observation in defaultsObservations {
-			observation.invalidate()
-		}
 	}
 }

--- a/Touch Bar Simulator/TouchBarWindow.swift
+++ b/Touch Bar Simulator/TouchBarWindow.swift
@@ -8,12 +8,19 @@ final class TouchBarWindow: NSPanel {
 		case floating, dockedToTop, dockedToBottom
 	}
 
-	var docking: Docking = .floating {
+	var docking: Docking! {
 		didSet {
-			switch docking {
+			if oldValue == .floating && docking != .floating {
+				defaults[.lastFloatingPos] = frame.origin
+			}
+
+			switch docking! {
 			case .floating:
 				styleMask.insert(.titled)
 				becameTitled()
+				if let prevPos = defaults[.lastFloatingPos] {
+					setFrameOrigin(prevPos)
+				}
 			case .dockedToTop:
 				styleMask.remove(.titled)
 				moveTo(x: .center, y: .top)

--- a/Touch Bar Simulator/TouchBarWindow.swift
+++ b/Touch Bar Simulator/TouchBarWindow.swift
@@ -6,28 +6,32 @@ private let windowTitle = "Touch Bar Simulator"
 final class TouchBarWindow: NSPanel {
 	enum Docking: String, Codable {
 		case floating, dockedToTop, dockedToBottom
+
+		func dock(window: TouchBarWindow) {
+			switch self {
+			case .floating:
+				window.styleMask.insert(.titled)
+				window.becameTitled()
+				if let prevPosition = defaults[.lastFloatingPosition] {
+					window.setFrameOrigin(prevPosition)
+				}
+			case .dockedToTop:
+				window.styleMask.remove(.titled)
+				window.moveTo(x: .center, y: .top)
+			case .dockedToBottom:
+				window.styleMask.remove(.titled)
+				window.moveTo(x: .center, y: .bottom)
+			}
+		}
 	}
 
-	var docking: Docking! {
+	var docking: Docking? {
 		didSet {
 			if oldValue == .floating && docking != .floating {
 				defaults[.lastFloatingPosition] = frame.origin
 			}
 
-			switch docking! {
-			case .floating:
-				styleMask.insert(.titled)
-				becameTitled()
-				if let prevPos = defaults[.lastFloatingPosition] {
-					setFrameOrigin(prevPos)
-				}
-			case .dockedToTop:
-				styleMask.remove(.titled)
-				moveTo(x: .center, y: .top)
-			case .dockedToBottom:
-				styleMask.remove(.titled)
-				moveTo(x: .center, y: .bottom)
-			}
+			docking?.dock(window: self)
 
 			setIsVisible(true)
 			orderFront(nil)

--- a/Touch Bar Simulator/TouchBarWindow.swift
+++ b/Touch Bar Simulator/TouchBarWindow.swift
@@ -79,7 +79,7 @@ final class TouchBarWindow: NSPanel {
 		defaultsObservations.append(defaults.observe(.windowTransparency) { change in
 			slider.doubleValue = change.newValue
 		})
-		slider.frame = CGRect(x: parentView.frame.width - 150, y: 4, width: 120, height: 11)
+		slider.frame = CGRect(x: parentView.frame.width - 160, y: 4, width: 140, height: 11)
 		slider.minValue = 0.5
 		return slider
 	}

--- a/Touch Bar Simulator/TouchBarWindow.swift
+++ b/Touch Bar Simulator/TouchBarWindow.swift
@@ -56,12 +56,15 @@ final class TouchBarWindow: NSPanel {
 		return button
 	}
 
+	private var transparencySliders: [ToolbarSlider] = []
+
 	func makeTransparencySlider(_ parentView: NSView) -> ToolbarSlider {
 		let slider = ToolbarSlider()
 		slider.frame = CGRect(x: parentView.frame.width - 150, y: 4, width: 120, height: 11)
 		slider.action = #selector(setTransparency)
 		slider.minValue = 0.5
 		slider.doubleValue = defaults[.windowTransparency]
+		transparencySliders.append(slider)
 		return slider
 	}
 
@@ -69,6 +72,9 @@ final class TouchBarWindow: NSPanel {
 	func setTransparency(sender: ToolbarSlider) {
 		self.alphaValue = CGFloat(sender.doubleValue)
 		defaults[.windowTransparency] = sender.doubleValue
+		for slider in transparencySliders where slider !== sender {
+			slider.doubleValue = sender.doubleValue
+		}
 	}
 
 	var showOnAllDesktops: Bool = false {

--- a/Touch Bar Simulator/TouchBarWindow.swift
+++ b/Touch Bar Simulator/TouchBarWindow.swift
@@ -75,12 +75,12 @@ final class TouchBarWindow: NSPanel {
 	private var transparencySlider: ToolbarSlider?
 
 	func makeTransparencySlider(_ parentView: NSView) -> ToolbarSlider {
-		let slider = ToolbarSlider().streamDoubleValue(to: .windowTransparency)
-		slider.frame = CGRect(x: parentView.frame.width - 150, y: 4, width: 120, height: 11)
-		slider.minValue = 0.5
+		let slider = ToolbarSlider().alwaysRedisplayOnValueChanged().streamDoubleValue(to: .windowTransparency)
 		defaultsObservations.append(defaults.observe(.windowTransparency) { change in
 			slider.doubleValue = change.newValue
 		})
+		slider.frame = CGRect(x: parentView.frame.width - 150, y: 4, width: 120, height: 11)
+		slider.minValue = 0.5
 		return slider
 	}
 

--- a/Touch Bar Simulator/TouchBarWindow.swift
+++ b/Touch Bar Simulator/TouchBarWindow.swift
@@ -75,7 +75,7 @@ final class TouchBarWindow: NSPanel {
 	private var transparencySlider: ToolbarSlider?
 
 	func makeTransparencySlider(_ parentView: NSView) -> ToolbarSlider {
-		let slider = ToolbarSlider().alwaysRedisplayOnValueChanged().streamDoubleValue(to: .windowTransparency)
+		let slider = ToolbarSlider().alwaysRedisplayOnValueChanged().bindDoubleValue(to: .windowTransparency)
 		defaultsObservations.append(defaults.observe(.windowTransparency) { change in
 			slider.doubleValue = change.newValue
 		})

--- a/Touch Bar Simulator/TouchBarWindow.swift
+++ b/Touch Bar Simulator/TouchBarWindow.swift
@@ -95,6 +95,27 @@ final class TouchBarWindow: NSPanel {
 		return false
 	}
 
+	func setUp() {
+		let view = self.contentView!
+		view.wantsLayer = true
+		view.layer?.backgroundColor = NSColor.black.cgColor
+
+		let touchBarView = TouchBarView()
+		self.setContentSize(touchBarView.bounds.adding(padding: 5).size)
+		touchBarView.frame = touchBarView.frame.centered(in: view.bounds)
+		view.addSubview(touchBarView)
+
+		self.center()
+		self.setFrameOrigin(CGPoint(x: self.frame.origin.x, y: 100))
+
+		self.setFrameUsingName(Constants.windowAutosaveName)
+		self.setFrameAutosaveName(Constants.windowAutosaveName)
+
+		self.orderFront(nil)
+	}
+
+	private var defaultsObservations: [DefaultsObservation] = []
+
 	convenience init() {
 		self.init(
 			contentRect: .zero,

--- a/Touch Bar Simulator/TouchBarWindow.swift
+++ b/Touch Bar Simulator/TouchBarWindow.swift
@@ -56,7 +56,7 @@ final class TouchBarWindow: NSPanel {
 			makeTransparencySlider(toolbarView)
 		)
 	}
-	
+
 	func removeTitlebar() {
 		styleMask.remove(.titled)
 	}

--- a/Touch Bar Simulator/TouchBarWindow.swift
+++ b/Touch Bar Simulator/TouchBarWindow.swift
@@ -34,6 +34,16 @@ final class TouchBarWindow: NSPanel {
 		}
 	}
 
+	var showOnAllDesktops: Bool = false {
+		didSet {
+			if showOnAllDesktops {
+				collectionBehavior = .canJoinAllSpaces
+			} else {
+				collectionBehavior = .moveToActiveSpace
+			}
+		}
+	}
+
 	func becameTitled() {
 		title = windowTitle
 		guard let toolbarView = self.toolbarView else {
@@ -74,16 +84,6 @@ final class TouchBarWindow: NSPanel {
 		defaults[.windowTransparency] = sender.doubleValue
 		for slider in transparencySliders where slider !== sender {
 			slider.doubleValue = sender.doubleValue
-		}
-	}
-
-	var showOnAllDesktops: Bool = false {
-		didSet {
-			if showOnAllDesktops {
-				collectionBehavior = .canJoinAllSpaces
-			} else {
-				collectionBehavior = .moveToActiveSpace
-			}
 		}
 	}
 
@@ -136,5 +136,18 @@ final class TouchBarWindow: NSPanel {
 		self.worksWhenModal = true
 		self.acceptsMouseMovedEvents = true
 		self.isMovableByWindowBackground = false
+
+		defaultsObservations.append(defaults.observe(.windowDocking) { change in
+			self.docking = change.newValue
+		})
+		defaultsObservations.append(defaults.observe(.showOnAllDesktops) { change in
+			self.showOnAllDesktops = change.newValue
+		})
+	}
+
+	deinit {
+		for observation in defaultsObservations {
+			observation.invalidate()
+		}
 	}
 }

--- a/Touch Bar Simulator/TouchBarWindow.swift
+++ b/Touch Bar Simulator/TouchBarWindow.swift
@@ -1,10 +1,10 @@
 import Cocoa
+import Defaults
 
-private let defaults = UserDefaults.standard
 private let windowTitle = "Touch Bar Simulator"
 
 final class TouchBarWindow: NSPanel {
-	enum Docking: String {
+	enum Docking: String, Codable {
 		case floating, dockedToTop, dockedToBottom
 	}
 
@@ -51,14 +51,14 @@ final class TouchBarWindow: NSPanel {
 		slider.frame = CGRect(x: toolbarView.frame.width - 150, y: 4, width: 120, height: 11)
 		slider.action = #selector(setTransparency)
 		slider.minValue = 0.5
-		slider.doubleValue = defaults.double(forKey: "windowTransparency")
+		slider.doubleValue = defaults[.windowTransparency]
 		return slider
 	}
 
 	@objc
 	func setTransparency(sender: ToolbarSlider) {
 		self.alphaValue = CGFloat(sender.doubleValue)
-		defaults.set(sender.doubleValue, forKey: "windowTransparency")
+		defaults[.windowTransparency] = sender.doubleValue
 	}
 
 	var showOnAllDesktops: Bool = false {

--- a/Touch Bar Simulator/TouchBarWindow.swift
+++ b/Touch Bar Simulator/TouchBarWindow.swift
@@ -16,10 +16,10 @@ final class TouchBarWindow: NSPanel {
 				becameTitled()
 			case .dockedToTop:
 				styleMask.remove(.titled)
-				setFrameOrigin(NSPoint(x: NSScreen.main!.visibleFrame.width / 2 - frame.width / 2, y: NSScreen.main!.visibleFrame.maxY - frame.height))
+				moveTo(x: .center, y: .top)
 			case .dockedToBottom:
 				styleMask.remove(.titled)
-				setFrameOrigin(NSPoint(x: NSScreen.main!.visibleFrame.width / 2 - frame.width / 2, y: NSScreen.main!.visibleFrame.minY))
+				moveTo(x: .center, y: .bottom)
 			}
 		}
 	}

--- a/Touch Bar Simulator/TouchBarWindow.swift
+++ b/Touch Bar Simulator/TouchBarWindow.swift
@@ -76,9 +76,6 @@ final class TouchBarWindow: NSPanel {
 
 	func makeTransparencySlider(_ parentView: NSView) -> ToolbarSlider {
 		let slider = ToolbarSlider().alwaysRedisplayOnValueChanged().bindDoubleValue(to: .windowTransparency)
-		defaultsObservations.append(defaults.observe(.windowTransparency) { change in
-			slider.doubleValue = change.newValue
-		})
 		slider.frame = CGRect(x: parentView.frame.width - 160, y: 4, width: 140, height: 11)
 		slider.minValue = 0.5
 		return slider

--- a/Touch Bar Simulator/TouchBarWindow.swift
+++ b/Touch Bar Simulator/TouchBarWindow.swift
@@ -1,5 +1,6 @@
 import Cocoa
 
+private let defaults = UserDefaults.standard
 private let windowTitle = "Touch Bar Simulator"
 
 final class TouchBarWindow: NSPanel {
@@ -12,7 +13,7 @@ final class TouchBarWindow: NSPanel {
 			switch docking {
 			case .floating:
 				styleMask.insert(.titled)
-				title = windowTitle
+				becameTitled()
 			case .dockedToTop:
 				styleMask.remove(.titled)
 				setFrameOrigin(NSPoint(x: NSScreen.main!.visibleFrame.width / 2 - frame.width / 2, y: NSScreen.main!.visibleFrame.maxY - frame.height))
@@ -21,6 +22,43 @@ final class TouchBarWindow: NSPanel {
 				setFrameOrigin(NSPoint(x: NSScreen.main!.visibleFrame.width / 2 - frame.width / 2, y: NSScreen.main!.visibleFrame.minY))
 			}
 		}
+	}
+
+	func becameTitled() {
+		title = windowTitle
+		guard let toolbarView = self.toolbarView else {
+			return
+		}
+		toolbarView.addSubviews(
+			makeScreenshotButton(toolbarView),
+			makeTransparencySlider(toolbarView)
+		)
+	}
+
+	func makeScreenshotButton(_ toolbarView: NSView) -> NSButton {
+		let button = NSButton()
+		button.image = #imageLiteral(resourceName: "ScreenshotButton")
+		button.imageScaling = .scaleProportionallyDown
+		button.isBordered = false
+		button.bezelStyle = .shadowlessSquare
+		button.frame = CGRect(x: toolbarView.frame.width - 19, y: 4, width: 16, height: 11)
+		button.action = #selector(AppDelegate.captureScreenshot)
+		return button
+	}
+
+	func makeTransparencySlider(_ toolbarView: NSView) -> ToolbarSlider {
+		let slider = ToolbarSlider()
+		slider.frame = CGRect(x: toolbarView.frame.width - 150, y: 4, width: 120, height: 11)
+		slider.action = #selector(setTransparency)
+		slider.minValue = 0.5
+		slider.doubleValue = defaults.double(forKey: "windowTransparency")
+		return slider
+	}
+
+	@objc
+	func setTransparency(sender: ToolbarSlider) {
+		self.alphaValue = CGFloat(sender.doubleValue)
+		defaults.set(sender.doubleValue, forKey: "windowTransparency")
 	}
 
 	var showOnAllDesktops: Bool = false {

--- a/Touch Bar Simulator/TouchBarWindow.swift
+++ b/Touch Bar Simulator/TouchBarWindow.swift
@@ -1,8 +1,6 @@
 import Cocoa
 import Defaults
 
-private let windowTitle = "Touch Bar Simulator"
-
 final class TouchBarWindow: NSPanel {
 	enum Docking: String, Codable {
 		case floating, dockedToTop, dockedToBottom
@@ -10,16 +8,15 @@ final class TouchBarWindow: NSPanel {
 		func dock(window: TouchBarWindow) {
 			switch self {
 			case .floating:
-				window.styleMask.insert(.titled)
-				window.becameTitled()
+				window.addTitlebar()
 				if let prevPosition = defaults[.lastFloatingPosition] {
 					window.setFrameOrigin(prevPosition)
 				}
 			case .dockedToTop:
-				window.styleMask.remove(.titled)
+				window.removeTitlebar()
 				window.moveTo(x: .center, y: .top)
 			case .dockedToBottom:
-				window.styleMask.remove(.titled)
+				window.removeTitlebar()
 				window.moveTo(x: .center, y: .bottom)
 			}
 		}
@@ -48,8 +45,9 @@ final class TouchBarWindow: NSPanel {
 		}
 	}
 
-	func becameTitled() {
-		title = windowTitle
+	func addTitlebar() {
+		styleMask.insert(.titled)
+		title = "Touch Bar Simulator"
 		guard let toolbarView = self.toolbarView else {
 			return
 		}
@@ -57,6 +55,10 @@ final class TouchBarWindow: NSPanel {
 			makeScreenshotButton(toolbarView),
 			makeTransparencySlider(toolbarView)
 		)
+	}
+	
+	func removeTitlebar() {
+		styleMask.remove(.titled)
 	}
 
 	func makeScreenshotButton(_ toolbarView: NSView) -> NSButton {
@@ -108,6 +110,8 @@ final class TouchBarWindow: NSPanel {
 		self.setContentSize(touchBarView.bounds.adding(padding: 5).size)
 		touchBarView.frame = touchBarView.frame.centered(in: view.bounds)
 		view.addSubview(touchBarView)
+
+		self.addTitlebar()
 
 		self.center()
 		self.setFrameOrigin(CGPoint(x: self.frame.origin.x, y: 100))

--- a/Touch Bar Simulator/TouchBarWindow.swift
+++ b/Touch Bar Simulator/TouchBarWindow.swift
@@ -11,14 +11,14 @@ final class TouchBarWindow: NSPanel {
 	var docking: Docking! {
 		didSet {
 			if oldValue == .floating && docking != .floating {
-				defaults[.lastFloatingPos] = frame.origin
+				defaults[.lastFloatingPosition] = frame.origin
 			}
 
 			switch docking! {
 			case .floating:
 				styleMask.insert(.titled)
 				becameTitled()
-				if let prevPos = defaults[.lastFloatingPos] {
+				if let prevPos = defaults[.lastFloatingPosition] {
 					setFrameOrigin(prevPos)
 				}
 			case .dockedToTop:

--- a/Touch Bar Simulator/TouchBarWindow.swift
+++ b/Touch Bar Simulator/TouchBarWindow.swift
@@ -75,11 +75,8 @@ final class TouchBarWindow: NSPanel {
 	private var transparencySlider: ToolbarSlider?
 
 	func makeTransparencySlider(_ parentView: NSView) -> ToolbarSlider {
-		let slider = ToolbarSlider()
+		let slider = ToolbarSlider().streamDoubleValue(to: .windowTransparency)
 		slider.frame = CGRect(x: parentView.frame.width - 150, y: 4, width: 120, height: 11)
-		slider.onAction = { sender in
-			defaults[.windowTransparency] = sender.doubleValue
-		}
 		slider.minValue = 0.5
 		defaultsObservations.append(defaults.observe(.windowTransparency) { change in
 			slider.doubleValue = change.newValue

--- a/Touch Bar Simulator/util.swift
+++ b/Touch Bar Simulator/util.swift
@@ -85,13 +85,15 @@ extension NSView {
 }
 
 extension NSMenuItem {
-	static func menuItem(_ title: String, keyEquivalent: String = "", keyModifiers: NSEvent.ModifierFlags? = nil, isOn: Bool = false, action: @escaping (NSMenuItem) -> Void) -> NSMenuItem {
+	static func menuItem(_ title: String, keyEquivalent: String = "", keyModifiers: NSEvent.ModifierFlags? = nil, isOn: Bool = false, action: ((NSMenuItem) -> Void)? = nil) -> NSMenuItem {
 		let item = NSMenuItem(title: title, action: nil, keyEquivalent: keyEquivalent)
 		if let keyModifiers = keyModifiers {
 			item.keyEquivalentModifierMask = keyModifiers
 		}
 		item.state = isOn ? .on : .off
-		item.onAction = action
+		if let action = action {
+			item.onAction = action
+		}
 		return item
 	}
 }

--- a/Touch Bar Simulator/util.swift
+++ b/Touch Bar Simulator/util.swift
@@ -179,6 +179,13 @@ extension TargetActionSender {
 			self.action = #selector(ActionTrampoline<Self>.performAction)
 		}
 	}
+	func addAction(_ action: @escaping ((Self) -> Void)) {
+		let lastAction = self.onAction
+		self.onAction = { sender in
+			lastAction?(sender)
+			action(sender)
+		}
+	}
 }
 
 extension NSApplication {

--- a/Touch Bar Simulator/util.swift
+++ b/Touch Bar Simulator/util.swift
@@ -96,6 +96,15 @@ extension NSMenuItem {
 	}
 }
 
+extension NSApplication {
+	func leftMouseIsDown() -> Bool {
+		return currentEvent?.type == .leftMouseDown
+	}
+	func optionKeyIsDown() -> Bool {
+		return currentEvent?.modifierFlags.contains(.option) ?? false
+	}
+}
+
 func pressKey(keyCode: CGKeyCode, flags: CGEventFlags = []) {
 	let eventSource = CGEventSource(stateID: .hidSystemState)
 	let keyDown = CGEvent(keyboardEventSource: eventSource, virtualKey: keyCode, keyDown: true)

--- a/Touch Bar Simulator/util.swift
+++ b/Touch Bar Simulator/util.swift
@@ -145,11 +145,17 @@ extension TargetActionSender {
 	}
 	```
 	*/
-	var onAction: (Self) -> Void {
+	var onAction: ((Self) -> Void)? {
 		get {
-			return (TargetActionSenderAssociatedKeys.trampoline[self] as! ActionTrampoline<Self>).action
+			return (TargetActionSenderAssociatedKeys.trampoline[self] as? ActionTrampoline<Self>)?.action
 		}
 		set {
+			guard let newValue = newValue else {
+				self.target = nil
+				self.action = nil
+				TargetActionSenderAssociatedKeys.trampoline[self] = nil
+				return
+			}
 			if let trampoline = TargetActionSenderAssociatedKeys.trampoline[self] {
 				self.target = trampoline
 				self.action = #selector(ActionTrampoline<Self>.performAction)

--- a/Touch Bar Simulator/util.swift
+++ b/Touch Bar Simulator/util.swift
@@ -170,11 +170,12 @@ extension TargetActionSender {
 }
 
 extension NSApplication {
-	func leftMouseIsDown() -> Bool {
+	var isLeftMouseDown: Bool {
 		return currentEvent?.type == .leftMouseDown
 	}
-	func optionKeyIsDown() -> Bool {
-		return currentEvent?.modifierFlags.contains(.option) ?? false
+
+	var isOptionKeyDown: Bool {
+		return NSEvent.modifierFlags.contains(.option)
 	}
 }
 

--- a/Touch Bar Simulator/util.swift
+++ b/Touch Bar Simulator/util.swift
@@ -84,6 +84,18 @@ extension NSView {
 	}
 }
 
+extension NSMenuItem {
+	static func menuItem(_ title: String, keyEquivalent: String = "", keyModifiers: NSEvent.ModifierFlags? = nil, isOn: Bool = false, action: @escaping (NSMenuItem) -> Void) -> NSMenuItem {
+		let item = NSMenuItem(title: title, action: nil, keyEquivalent: keyEquivalent)
+		if let keyModifiers = keyModifiers {
+			item.keyEquivalentModifierMask = keyModifiers
+		}
+		item.state = isOn ? .on : .off
+		item.onAction = action
+		return item
+	}
+}
+
 final class AssociatedObject<T: Any> {
 	subscript(index: Any) -> T? {
 		get {

--- a/Touch Bar Simulator/util.swift
+++ b/Touch Bar Simulator/util.swift
@@ -54,7 +54,9 @@ extension NSWindow {
 	}
 
 	func moveTo(x xPositioning: MoveXPositioning, y yPositioning: MoveYPositioning) {
-		let visibleFrame = NSScreen.main!.visibleFrame
+		guard let visibleFrame = NSScreen.main?.visibleFrame else {
+			return
+		}
 
 		let x: CGFloat, y: CGFloat
 		switch xPositioning {

--- a/Touch Bar Simulator/util.swift
+++ b/Touch Bar Simulator/util.swift
@@ -89,16 +89,26 @@ extension NSView {
 }
 
 extension NSMenuItem {
-	static func menuItem(_ title: String, keyEquivalent: String = "", keyModifiers: NSEvent.ModifierFlags? = nil, isOn: Bool = false, action: ((NSMenuItem) -> Void)? = nil) -> NSMenuItem {
-		let item = NSMenuItem(title: title, action: nil, keyEquivalent: keyEquivalent)
+	var isChecked: Bool {
+		get {
+			return state == .on
+		}
+		set {
+			state = newValue ? .on : .off
+		}
+	}
+}
+
+extension NSMenuItem {
+	convenience init(_ title: String, keyEquivalent: String = "", keyModifiers: NSEvent.ModifierFlags? = nil, isChecked: Bool = false, action: ((NSMenuItem) -> Void)? = nil) {
+		self.init(title: title, action: nil, keyEquivalent: keyEquivalent)
 		if let keyModifiers = keyModifiers {
-			item.keyEquivalentModifierMask = keyModifiers
+			self.keyEquivalentModifierMask = keyModifiers
 		}
-		item.state = isOn ? .on : .off
+		self.isChecked = isChecked
 		if let action = action {
-			item.onAction = action
+			self.onAction = action
 		}
-		return item
 	}
 }
 

--- a/Touch Bar Simulator/util.swift
+++ b/Touch Bar Simulator/util.swift
@@ -45,6 +45,37 @@ extension NSWindow {
 	var toolbarView: NSView? {
 		return standardWindowButton(.closeButton)?.superview
 	}
+
+	enum MoveXPositioning {
+		case left, center, right
+	}
+	enum MoveYPositioning {
+		case top, center, bottom
+	}
+
+	func moveTo(x xPositioning: MoveXPositioning, y yPositioning: MoveYPositioning) {
+		let visibleFrame = NSScreen.main!.visibleFrame
+
+		let x: CGFloat, y: CGFloat
+		switch xPositioning {
+		case .left:
+			x = visibleFrame.minX
+		case .center:
+			x = visibleFrame.midX - frame.width / 2
+		case .right:
+			x = visibleFrame.maxX - frame.width
+		}
+		switch yPositioning {
+		case .top:
+			y = visibleFrame.maxY - frame.height
+		case .center:
+			y = visibleFrame.midY - frame.height / 2
+		case .bottom:
+			y = visibleFrame.minY
+		}
+
+		setFrameOrigin(CGPoint(x: x, y: y))
+	}
 }
 
 extension NSView {

--- a/readme.md
+++ b/readme.md
@@ -64,6 +64,12 @@ Xcode 10 moved the required private symbols needed to trigger the Touch Bar simu
 ```
 
 
+## Related
+
+- [Gifski](https://github.com/sindresorhus/gifski-app) - Convert videos to high-quality GIFs on your Mac
+- [More apps…](https://sindresorhus.com/#apps)
+
+
 ## License
 
 MIT © [Sindre Sorhus](https://sindresorhus.com)

--- a/readme.md
+++ b/readme.md
@@ -12,7 +12,7 @@ You can add a shortcut in `System Preferences` → `Keyboard` → `Shortcuts` �
 
 <img src="screenshot.png" width="1129">
 
-*Check out my other [macOS apps](https://sindresorhus.com/#apps)*
+*Check out my other [macOS apps](https://sindresorhus.com/apps)*
 
 <a href="https://www.patreon.com/sindresorhus">
 	<img src="https://c5.patreon.com/external/logo/become_a_patron_button@2x.png" width="160">

--- a/readme.md
+++ b/readme.md
@@ -2,9 +2,11 @@
 
 > Use the Touch Bar on any Mac
 
-Launch the Touch Bar simulator from anywhere without needing to have Xcode installed, whereas Apple requires you to launch it from inside Xcode. It also comes with a handy transparency slider, a screenshot button, and a service to toggle the Touch Bar in the Services menu or with a keyboard shortcut.
+Launch the Touch Bar simulator from anywhere without needing to have Xcode installed, whereas Apple requires you to launch it from inside Xcode. It also comes with a handy transparency slider, a screenshot button, and a menu bar icon and system service to toggle the Touch Bar with a click or keyboard shortcut.
 
-You can add a shortcut in `System Preferences` → `Keyboard` → `Shortcuts` → `Services` → `Toggle Touch Bar`.
+Right- or option-clicking the menu bar icon displays a menu with options to dock the window to the top or bottom of the screen, make it show on all desktops at once, access toolbar features in docked mode, or quit the app.
+
+You can add a toggle shortcut in `System Preferences` → `Keyboard` → `Shortcuts` → `Services` → `Toggle Touch Bar`.
 
 **Important:** If clicking in the simulator or the screenshot button is not working, you need to go to "System Preferences" → "Security & Privacy" → "Accessibility", and ensure "Touch Bar Simulator.app" is checked. If it's already checked, try unchecking and checking it again.
 
@@ -39,7 +41,7 @@ $ brew cask install touch-bar-simulator
 
 You can capture a screenshot of the Touch Bar by either:
 
-1. Clicking the screenshot button in the Touch Bar window which saves it to `~/Desktop`.
+1. Clicking the screenshot button in the Touch Bar window or options menu which saves it to `~/Desktop`.
 2. Pressing <kbd>⇧⌘6</kbd> which saves it to `~/Desktop`.
 3. Pressing <kbd>⌃⇧⌘6</kbd> which saves it to the clipboard.
 


### PR DESCRIPTION
Adds a menu bar item for the app. Left clicking hides and shows the touch bar window, while right or option-clicking displays a menu with options for docking to the top or bottom of the screen and showing on all desktops at once, along with a quit button. Closing the touch bar window now simply hides it, and it may be shown again by clicking the status item.

<img width="247" alt="options menu" src="https://user-images.githubusercontent.com/16456186/50531443-e489e700-0ad7-11e9-9b34-11ea56bc42c4.png">

Proper template image artwork is still needed. The app icon is currently used as a placeholder, but it is, of course, not designed for this task, and it looks very out of place.

---

Fixes #30