### PR TITLE
Add ability to auto-hide and reveal Touch Bar

### DIFF
--- a/Touch Bar Simulator/AppDelegate.swift
+++ b/Touch Bar Simulator/AppDelegate.swift
@@ -85,8 +85,6 @@ extension AppDelegate: NSMenuDelegate {
 
 		menu.addItem(NSMenuItem("Show on All Desktops").bindState(to: .showOnAllDesktops))
 
-		menu.addItem(NSMenuItem.separator())
-
 		menu.addItem(NSMenuItem("Dock Behavior").bindState(to: .dockBehavior))
 
 		menu.addItem(NSMenuItem.separator())

--- a/Touch Bar Simulator/AppDelegate.swift
+++ b/Touch Bar Simulator/AppDelegate.swift
@@ -85,7 +85,7 @@ extension AppDelegate: NSMenuDelegate {
 
 		menu.addItem(NSMenuItem("Show on All Desktops").bindState(to: .showOnAllDesktops))
 
-		menu.addItem(NSMenuItem("Dock Behavior").bindState(to: .dockBehavior))
+		menu.addItem(NSMenuItem("Hide and Show Automatically").bindState(to: .dockBehavior))
 
 		menu.addItem(NSMenuItem.separator())
 

--- a/Touch Bar Simulator/AppDelegate.swift
+++ b/Touch Bar Simulator/AppDelegate.swift
@@ -87,6 +87,10 @@ extension AppDelegate: NSMenuDelegate {
 
 		menu.addItem(NSMenuItem.separator())
 
+		menu.addItem(NSMenuItem("Dock Behavior").bindState(to: .dockBehavior))
+
+		menu.addItem(NSMenuItem.separator())
+
 		menu.addItem(NSMenuItem("Quit Touch Bar Simulator", keyEquivalent: "q") { _ in
 			NSApp.terminate(nil)
 		})
@@ -107,6 +111,10 @@ extension AppDelegate: NSMenuDelegate {
 	}
 
 	private func statusItemButtonClicked() {
+		// When the user explicit wants the touch bar to appear when `dockBahavior` should be disabled.
+		// This is also how the macOS dock bahaves.
+		defaults[.dockBehavior] = false
+
 		toggleView()
 
 		if window.isVisible {

--- a/Touch Bar Simulator/AppDelegate.swift
+++ b/Touch Bar Simulator/AppDelegate.swift
@@ -109,8 +109,8 @@ extension AppDelegate: NSMenuDelegate {
 	}
 
 	private func statusItemButtonClicked() {
-		// When the user explicit wants the touch bar to appear when `dockBahavior` should be disabled.
-		// This is also how the macOS dock behaves.
+		// When the user explicitly wants the Touch Bar to appear then `dockBahavior` should be disabled.
+		// This is also how the macOS Dock behaves.
 		defaults[.dockBehavior] = false
 
 		toggleView()

--- a/Touch Bar Simulator/AppDelegate.swift
+++ b/Touch Bar Simulator/AppDelegate.swift
@@ -110,7 +110,7 @@ extension AppDelegate: NSMenuDelegate {
 
 	private func statusItemButtonClicked() {
 		// When the user explicit wants the touch bar to appear when `dockBahavior` should be disabled.
-		// This is also how the macOS dock bahaves.
+		// This is also how the macOS dock behaves.
 		defaults[.dockBehavior] = false
 
 		toggleView()

--- a/Touch Bar Simulator/Constants.swift
+++ b/Touch Bar Simulator/Constants.swift
@@ -10,4 +10,5 @@ extension Defaults.Keys {
 	static let windowDocking = Key<TouchBarWindow.Docking>("windowDocking", default: .floating)
 	static let showOnAllDesktops = Key<Bool>("showOnAllDesktops", default: false)
 	static let lastFloatingPosition = OptionalKey<CGPoint>("lastFloatingPosition")
+	static let dockBehavior = Key<Bool>("dockBehavior", default: false)
 }

--- a/Touch Bar Simulator/Constants.swift
+++ b/Touch Bar Simulator/Constants.swift
@@ -11,4 +11,5 @@ extension Defaults.Keys {
 	static let showOnAllDesktops = Key<Bool>("showOnAllDesktops", default: false)
 	static let lastFloatingPosition = OptionalKey<CGPoint>("lastFloatingPosition")
 	static let dockBehavior = Key<Bool>("dockBehavior", default: false)
+	static let lastWindowDockingWithDockBehavior = Key<TouchBarWindow.Docking>("windowDockingWithDockBehavior", default: .dockedToTop)
 }

--- a/Touch Bar Simulator/TouchBarWindow.swift
+++ b/Touch Bar Simulator/TouchBarWindow.swift
@@ -99,10 +99,8 @@ final class TouchBarWindow: NSPanel {
 
 	@objc
 	func handleDockBehavior() {
-		guard self.docking != nil else {
-			return
-		}
-		guard let screen = NSScreen.main else {
+		guard self.docking != nil,
+			let screen = NSScreen.main else {
 			return
 		}
 		var detectionRect: NSRect = .zero

--- a/Touch Bar Simulator/TouchBarWindow.swift
+++ b/Touch Bar Simulator/TouchBarWindow.swift
@@ -70,8 +70,6 @@ final class TouchBarWindow: NSPanel {
 
 	func startDockBehaviorTimer() {
 		stopDockBehaviorTimer()
-		// Throttles the function to only execute every 1/10 second.
-		// Without any throttling the function would be very expensive and use an average of 7% CPU (on my machine) which is too much IMO.
 		dockBehaviorTimer = Timer.scheduledTimer(timeInterval: 0.1, target: self, selector: #selector(handleDockBehavior), userInfo: nil, repeats: true)
 		dockBehaviorTimer!.fire()
 	}

--- a/Touch Bar Simulator/TouchBarWindow.swift
+++ b/Touch Bar Simulator/TouchBarWindow.swift
@@ -87,10 +87,9 @@ final class TouchBarWindow: NSPanel {
 	var dockBehavior: Bool = defaults[.dockBehavior] {
 		didSet {
 			if dockBehavior {
-				guard self.docking != nil else {
-					return
-				}
-				guard self.docking! != .floating else {
+				guard self.docking != nil &&
+					self.docking! == .dockedToBottom ||
+					self.docking! == .dockedToTop else {
 					return
 				}
 				startDockBehaviorTimer()

--- a/Touch Bar Simulator/TouchBarWindow.swift
+++ b/Touch Bar Simulator/TouchBarWindow.swift
@@ -81,15 +81,22 @@ final class TouchBarWindow: NSPanel {
 
 	var dockBehavior: Bool = defaults[.dockBehavior] {
 		didSet {
+			guard self.docking != nil else {
+				return
+			}
+			if self.docking! == .dockedToBottom || self.docking! == .dockedToTop {
+				defaults[.lastWindowDockingWithDockBehavior] = self.docking!
+			}
 			if dockBehavior {
-				guard self.docking != nil &&
-					self.docking! == .dockedToBottom ||
-					self.docking! == .dockedToTop else {
-					return
+				if self.docking! == .dockedToBottom || self.docking! == .dockedToTop {
+					self.docking = defaults[.lastWindowDockingWithDockBehavior]
+					startDockBehaviorTimer()
+				} else if self.docking! == .floating {
+					defaults[.windowDocking] = defaults[.lastWindowDockingWithDockBehavior]
 				}
-				startDockBehaviorTimer()
 			} else {
 				stopDockBehaviorTimer()
+				self.setIsVisible(true)
 			}
 		}
 	}

--- a/Touch Bar Simulator/TouchBarWindow.swift
+++ b/Touch Bar Simulator/TouchBarWindow.swift
@@ -320,7 +320,7 @@ final class TouchBarWindow: NSPanel {
 		setFrameUsingName(Constants.windowAutosaveName)
 		setFrameAutosaveName(Constants.windowAutosaveName)
 
-		// Prevent the touch bar from shortly becoming visible.
+		// Prevent the Touch Bar from momentarily becoming visible.
 		if !dockBehavior {
 			orderFront(nil)
 		}

--- a/Touch Bar Simulator/TouchBarWindow.swift
+++ b/Touch Bar Simulator/TouchBarWindow.swift
@@ -66,21 +66,17 @@ final class TouchBarWindow: NSPanel {
 		}
 	}
 
-	var dockBehaviorTimer: Timer?
+	var dockBehaviorTimer = Timer()
 	var showTouchBarTimer = Timer()
 
 	func startDockBehaviorTimer() {
 		stopDockBehaviorTimer()
 		dockBehaviorTimer = Timer.scheduledTimer(timeInterval: 0.1, target: self, selector: #selector(handleDockBehavior), userInfo: nil, repeats: true)
-		dockBehaviorTimer!.fire()
 	}
 
 	func stopDockBehaviorTimer() {
-		guard dockBehaviorTimer != nil else {
-			return
-		}
-		dockBehaviorTimer!.invalidate()
-		dockBehaviorTimer = nil
+		dockBehaviorTimer.invalidate()
+		dockBehaviorTimer = Timer()
 	}
 
 	var dockBehavior: Bool = defaults[.dockBehavior] {
@@ -108,7 +104,7 @@ final class TouchBarWindow: NSPanel {
 		var detectionRect: NSRect = .zero
 		if self.docking! == .dockedToBottom {
 			if self.isVisible {
-				detectionRect = NSRect(x: 0, y: 0, width: visibleFrame.width, height: self.frame.height+(screenFrame.height - visibleFrame.height - NSStatusBar.system.thickness))
+				detectionRect = NSRect(x: 0, y: 0, width: visibleFrame.width, height: self.frame.height + (screenFrame.height - visibleFrame.height - NSStatusBar.system.thickness))
 			} else {
 				detectionRect = NSRect(x: 0, y: 0, width: visibleFrame.width, height: 1)
 			}
@@ -117,13 +113,13 @@ final class TouchBarWindow: NSPanel {
 				detectionRect = NSRect(
 					x: 0,
 					// without `+ 1` the touch bar would glitch (toggling rapidly).
-					y: visibleFrame.height - self.frame.height - NSStatusBar.system.thickness + 1,
+					y: screenFrame.height - self.frame.height - NSStatusBar.system.thickness + 1,
 					width: visibleFrame.width,
 					height: self.frame.height + NSStatusBar.system.thickness)
 			} else {
 				detectionRect = NSRect(
 					x: 0,
-					y: visibleFrame.height,
+					y: screenFrame.height,
 					width: visibleFrame.width,
 					height: 1)
 			}

--- a/Touch Bar Simulator/TouchBarWindow.swift
+++ b/Touch Bar Simulator/TouchBarWindow.swift
@@ -28,6 +28,10 @@ final class TouchBarWindow: NSPanel {
 				defaults[.lastFloatingPosition] = frame.origin
 			}
 
+			if self.docking == .floating {
+				dockBehavior = false
+			}
+
 			// Prevent the Touch Bar from momentarily becoming visible.
 			if self.docking == .floating || !dockBehavior {
 				stopDockBehaviorTimer()
@@ -71,6 +75,7 @@ final class TouchBarWindow: NSPanel {
 
 	var dockBehavior: Bool = defaults[.dockBehavior] {
 		didSet {
+			defaults[.dockBehavior] = self.dockBehavior
 			if self.docking == .dockedToBottom || self.docking == .dockedToTop {
 				defaults[.lastWindowDockingWithDockBehavior] = self.docking
 			}

--- a/Touch Bar Simulator/TouchBarWindow.swift
+++ b/Touch Bar Simulator/TouchBarWindow.swift
@@ -67,6 +67,7 @@ final class TouchBarWindow: NSPanel {
 	}
 
 	var dockBehaviorTimer: Timer?
+	var showTouchBarTimer = Timer()
 
 	func startDockBehaviorTimer() {
 		stopDockBehaviorTimer()
@@ -128,13 +129,14 @@ final class TouchBarWindow: NSPanel {
 		}
 		let mouseLocation = NSEvent.mouseLocation
 		if detectionRect.contains(mouseLocation) {
-			if !self.isVisible {
-				self.setIsVisible(true)
+			if !showTouchBarTimer.isValid {
+				showTouchBarTimer = Timer.scheduledTimer(withTimeInterval: 0.3, repeats: false, block: { timer in
+					self.setIsVisible(true)
+				})
 			}
 		} else {
-			if self.isVisible {
-				self.setIsVisible(false)
-			}
+			showTouchBarTimer.invalidate()
+			self.setIsVisible(false)
 		}
 	}
 


### PR DESCRIPTION
Fixes #38.

I have chosen to name this feature "Dock Behavior".

Note that  `dockBahvior` will be set to false when the user clicks the status bar icon. This is done to prevent the Touch Bar from quickly appearing and then disappear again. Also, the user probably wants the Touch Bar to stay when clicking the status bar icon.
