### PR TITLE
Add Open at Login setting

### DIFF
--- a/Touch Bar Simulator Launcher/AppDelegate.swift
+++ b/Touch Bar Simulator Launcher/AppDelegate.swift
@@ -1,0 +1,9 @@
+import Cocoa
+
+@NSApplicationMain
+class AppDelegate: NSObject, NSApplicationDelegate {
+    func applicationDidFinishLaunching(_ aNotification: Notification) {
+		NSWorkspace.shared.launchApplication(withBundleIdentifier: "com.sindresorhus.Touch-Bar-Simulator", options: [], additionalEventParamDescriptor: nil, launchIdentifier: nil)
+		NSApp.terminate(self)
+    }
+}

--- a/Touch Bar Simulator Launcher/Base.lproj/MainMenu.xib
+++ b/Touch Bar Simulator Launcher/Base.lproj/MainMenu.xib
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14490.70"/>
+    </dependencies>
+    <objects>
+        <customObject id="-2" userLabel="File's Owner" customClass="NSApplication">
+            <connections>
+                <outlet property="delegate" destination="Voe-Tx-rLC" id="GzC-gU-4Uq"/>
+            </connections>
+        </customObject>
+        <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
+        <customObject id="-3" userLabel="Application"/>
+        <customObject id="Voe-Tx-rLC" customClass="AppDelegate" customModule="Touch_Bar_Simulator_Launcher" customModuleProvider="target"/>
+    </objects>
+</document>

--- a/Touch Bar Simulator Launcher/Info.plist
+++ b/Touch Bar Simulator Launcher/Info.plist
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIconFile</key>
+	<string></string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>3.2.0</string>
+	<key>CFBundleVersion</key>
+	<string>5</string>
+	<key>LSApplicationCategoryType</key>
+	<string>public.app-category.developer-tools</string>
+	<key>LSMinimumSystemVersion</key>
+	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
+	<key>NSHumanReadableCopyright</key>
+	<string>Copyright © 2019 Sindre Sorhus. All rights reserved.</string>
+	<key>NSMainNibFile</key>
+	<string>MainMenu</string>
+	<key>NSPrincipalClass</key>
+	<string>NSApplication</string>
+	<key>LSBackgroundOnly</key>
+	<true/>
+</dict>
+</plist>

--- a/Touch Bar Simulator.xcodeproj/project.pbxproj
+++ b/Touch Bar Simulator.xcodeproj/project.pbxproj
@@ -7,6 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		3C2E1377231C3F2900E0EB8E /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C2E1376231C3F2900E0EB8E /* AppDelegate.swift */; };
+		3C2E137C231C3F2900E0EB8E /* MainMenu.xib in Resources */ = {isa = PBXBuildFile; fileRef = 3C2E137A231C3F2900E0EB8E /* MainMenu.xib */; };
+		3C2E1384231C459B00E0EB8E /* Touch Bar Simulator Launcher.app in Embed Login Items */ = {isa = PBXBuildFile; fileRef = 3C2E1374231C3F2900E0EB8E /* Touch Bar Simulator Launcher.app */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		3C37035421FBEBD300177657 /* Defaults.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3C37035321FBEBD300177657 /* Defaults.framework */; };
 		3C37035521FBEBD300177657 /* Defaults.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 3C37035321FBEBD300177657 /* Defaults.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		3C8493AD21FD3B7F00F12966 /* Glue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C8493AC21FD3B7F00F12966 /* Glue.swift */; };
@@ -26,7 +29,28 @@
 		E3FE2CC51E726CE800C6713A /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = E3FE2CC41E726CE800C6713A /* Assets.xcassets */; };
 /* End PBXBuildFile section */
 
+/* Begin PBXContainerItemProxy section */
+		3C2E1385231C45CA00E0EB8E /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = E3FE2CB71E726CE800C6713A /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 3C2E1373231C3F2900E0EB8E;
+			remoteInfo = "Touch Bar Simulator Launcher";
+		};
+/* End PBXContainerItemProxy section */
+
 /* Begin PBXCopyFilesBuildPhase section */
+		3C2E1383231C456900E0EB8E /* Embed Login Items */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = Contents/Library/LoginItems;
+			dstSubfolderSpec = 1;
+			files = (
+				3C2E1384231C459B00E0EB8E /* Touch Bar Simulator Launcher.app in Embed Login Items */,
+			);
+			name = "Embed Login Items";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		E3FA3A901E784C5F00A7F2EA /* Embed Frameworks */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
@@ -44,6 +68,10 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		3C2E1374231C3F2900E0EB8E /* Touch Bar Simulator Launcher.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Touch Bar Simulator Launcher.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		3C2E1376231C3F2900E0EB8E /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		3C2E137B231C3F2900E0EB8E /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/MainMenu.xib; sourceTree = "<group>"; };
+		3C2E137D231C3F2900E0EB8E /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		3C37035321FBEBD300177657 /* Defaults.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Defaults.framework; path = Carthage/Build/Mac/Defaults.framework; sourceTree = "<group>"; };
 		3C8493AC21FD3B7F00F12966 /* Glue.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = Glue.swift; sourceTree = "<group>"; usesTabs = 1; };
 		AF6C7BC51E7FAF38004A27E0 /* ToolbarSlider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = ToolbarSlider.swift; sourceTree = "<group>"; usesTabs = 1; };
@@ -64,6 +92,13 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		3C2E1371231C3F2900E0EB8E /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		E3FE2CBC1E726CE800C6713A /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -78,6 +113,16 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		3C2E1375231C3F2900E0EB8E /* Touch Bar Simulator Launcher */ = {
+			isa = PBXGroup;
+			children = (
+				3C2E1376231C3F2900E0EB8E /* AppDelegate.swift */,
+				3C2E137A231C3F2900E0EB8E /* MainMenu.xib */,
+				3C2E137D231C3F2900E0EB8E /* Info.plist */,
+			);
+			path = "Touch Bar Simulator Launcher";
+			sourceTree = "<group>";
+		};
 		E356A16421028DAB000148AD /* Other */ = {
 			isa = PBXGroup;
 			children = (
@@ -93,6 +138,7 @@
 			isa = PBXGroup;
 			children = (
 				E3FE2CC11E726CE800C6713A /* Touch Bar Simulator */,
+				3C2E1375231C3F2900E0EB8E /* Touch Bar Simulator Launcher */,
 				E3FE2CC01E726CE800C6713A /* Products */,
 				E3FE2CD91E7272AD00C6713A /* Frameworks */,
 				E39A1589214D011F00F86D5D /* SkyLight.framework */,
@@ -105,6 +151,7 @@
 			isa = PBXGroup;
 			children = (
 				E3FE2CBF1E726CE800C6713A /* Touch Bar Simulator.app */,
+				3C2E1374231C3F2900E0EB8E /* Touch Bar Simulator Launcher.app */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -137,6 +184,24 @@
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
+		3C2E1373231C3F2900E0EB8E /* Touch Bar Simulator Launcher */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 3C2E1381231C3F2900E0EB8E /* Build configuration list for PBXNativeTarget "Touch Bar Simulator Launcher" */;
+			buildPhases = (
+				3C2E1382231C453B00E0EB8E /* SwiftLint */,
+				3C2E1370231C3F2900E0EB8E /* Sources */,
+				3C2E1371231C3F2900E0EB8E /* Frameworks */,
+				3C2E1372231C3F2900E0EB8E /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "Touch Bar Simulator Launcher";
+			productName = "Touch Bar Simulator Launcher";
+			productReference = 3C2E1374231C3F2900E0EB8E /* Touch Bar Simulator Launcher.app */;
+			productType = "com.apple.product-type.application";
+		};
 		E3FE2CBE1E726CE800C6713A /* Touch Bar Simulator */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = E3FE2CCC1E726CE800C6713A /* Build configuration list for PBXNativeTarget "Touch Bar Simulator" */;
@@ -146,10 +211,12 @@
 				E3FE2CBC1E726CE800C6713A /* Frameworks */,
 				E3FE2CBD1E726CE800C6713A /* Resources */,
 				E3FA3A901E784C5F00A7F2EA /* Embed Frameworks */,
+				3C2E1383231C456900E0EB8E /* Embed Login Items */,
 			);
 			buildRules = (
 			);
 			dependencies = (
+				3C2E1386231C45CA00E0EB8E /* PBXTargetDependency */,
 			);
 			name = "Touch Bar Simulator";
 			productName = "Touch Bar Simulator";
@@ -162,10 +229,18 @@
 		E3FE2CB71E726CE800C6713A /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastSwiftUpdateCheck = 0820;
+				LastSwiftUpdateCheck = 1020;
 				LastUpgradeCheck = 0930;
 				ORGANIZATIONNAME = "Sindre Sorhus";
 				TargetAttributes = {
+					3C2E1373231C3F2900E0EB8E = {
+						CreatedOnToolsVersion = 10.2.1;
+						SystemCapabilities = {
+							com.apple.Sandbox = {
+								enabled = 0;
+							};
+						};
+					};
 					E3FE2CBE1E726CE800C6713A = {
 						CreatedOnToolsVersion = 8.2.1;
 						DevelopmentTeam = YG56YK5RN5;
@@ -184,6 +259,7 @@
 			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				en,
 				Base,
 			);
 			mainGroup = E3FE2CB61E726CE800C6713A;
@@ -192,11 +268,20 @@
 			projectRoot = "";
 			targets = (
 				E3FE2CBE1E726CE800C6713A /* Touch Bar Simulator */,
+				3C2E1373231C3F2900E0EB8E /* Touch Bar Simulator Launcher */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		3C2E1372231C3F2900E0EB8E /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				3C2E137C231C3F2900E0EB8E /* MainMenu.xib in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		E3FE2CBD1E726CE800C6713A /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -208,6 +293,25 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		3C2E1382231C453B00E0EB8E /* SwiftLint */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = SwiftLint;
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if which swiftlint >/dev/null; then\n    swiftlint\nelse\n    echo \"warning: SwiftLint not installed\"\nfi\n";
+			showEnvVarsInLog = 0;
+		};
 		E3679C9A215A1ECA0080270F /* SwiftLint */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -230,6 +334,14 @@
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		3C2E1370231C3F2900E0EB8E /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				3C2E1377231C3F2900E0EB8E /* AppDelegate.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		E3FE2CBB1E726CE800C6713A /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -247,7 +359,73 @@
 		};
 /* End PBXSourcesBuildPhase section */
 
+/* Begin PBXTargetDependency section */
+		3C2E1386231C45CA00E0EB8E /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 3C2E1373231C3F2900E0EB8E /* Touch Bar Simulator Launcher */;
+			targetProxy = 3C2E1385231C45CA00E0EB8E /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin PBXVariantGroup section */
+		3C2E137A231C3F2900E0EB8E /* MainMenu.xib */ = {
+			isa = PBXVariantGroup;
+			children = (
+				3C2E137B231C3F2900E0EB8E /* Base */,
+			);
+			name = MainMenu.xib;
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
+
 /* Begin XCBuildConfiguration section */
+		3C2E137F231C3F2900E0EB8E /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				INFOPLIST_FILE = "Touch Bar Simulator Launcher/Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.sindresorhus.Touch-Bar-Simulator-Launcher";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		3C2E1380231C3F2900E0EB8E /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				INFOPLIST_FILE = "Touch Bar Simulator Launcher/Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.sindresorhus.Touch-Bar-Simulator-Launcher";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
 		E3FE2CCA1E726CE800C6713A /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -435,6 +613,15 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		3C2E1381231C3F2900E0EB8E /* Build configuration list for PBXNativeTarget "Touch Bar Simulator Launcher" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				3C2E137F231C3F2900E0EB8E /* Debug */,
+				3C2E1380231C3F2900E0EB8E /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		E3FE2CBA1E726CE800C6713A /* Build configuration list for PBXProject "Touch Bar Simulator" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/Touch Bar Simulator/AppDelegate.swift
+++ b/Touch Bar Simulator/AppDelegate.swift
@@ -1,4 +1,5 @@
 import Cocoa
+import ServiceManagement
 import Sparkle
 import Defaults
 
@@ -25,6 +26,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 		_ = SUUpdater()
 		_ = window
 		_ = statusItem
+
+		defaults.observe(.openAtLogin, tiedToLifetimeOf: self, options: [.initial, .new]) { change in
+			SMLoginItemSetEnabled("com.sindresorhus.Touch-Bar-Simulator-Launcher" as CFString, change.newValue)
+		}
 	}
 
 	@objc
@@ -86,6 +91,8 @@ extension AppDelegate: NSMenuDelegate {
 		menu.addItem(NSMenuItem("Show on All Desktops").bindState(to: .showOnAllDesktops))
 
 		menu.addItem(NSMenuItem("Hide and Show Automatically").bindState(to: .dockBehavior))
+
+		menu.addItem(NSMenuItem("Open at Login").bindState(to: .openAtLogin))
 
 		menu.addItem(NSMenuItem.separator())
 

--- a/Touch Bar Simulator/Constants.swift
+++ b/Touch Bar Simulator/Constants.swift
@@ -12,4 +12,5 @@ extension Defaults.Keys {
 	static let lastFloatingPosition = OptionalKey<CGPoint>("lastFloatingPosition")
 	static let dockBehavior = Key<Bool>("dockBehavior", default: false)
 	static let lastWindowDockingWithDockBehavior = Key<TouchBarWindow.Docking>("windowDockingWithDockBehavior", default: .dockedToTop)
+	static let openAtLogin = Key<Bool>("openAtLogin", default: false)
 }


### PR DESCRIPTION
Adds a menu item setting that uses ServiceManagement's `SMLoginItemSetEnabled()` and a simple helper app to launch at login.

(Basically) closes #50.