### PR TITLE
Specify "opacity" rather than "transparency"

### DIFF
--- a/Touch Bar Simulator/AppDelegate.swift
+++ b/Touch Bar Simulator/AppDelegate.swift
@@ -113,8 +113,8 @@ extension AppDelegate: NSMenuDelegate {
 			menu.addItem(sliderMenuItem("Padding", boundTo: .windowPadding, min: 0.0, max: 120.0))
 		}
 
-		menu.addItem(NSMenuItem("Transparency"))
-		menu.addItem(sliderMenuItem("Transparency", boundTo: .windowTransparency, min: 0.5, max: 1.0))
+		menu.addItem(NSMenuItem("Opacity"))
+		menu.addItem(sliderMenuItem("Opacity", boundTo: .windowTransparency, min: 0.5, max: 1.0))
 
 		menu.addItem(NSMenuItem.separator())
 


### PR DESCRIPTION
The "Transparency" slider in the menu should be called _opacity_. Greater opacity = more opaque, greater transparency = more transparent aka _less_ opaque. And right now, moving the slider to the right (increasing its value) makes the window more opaque.

This PR changes the item title accordingly.