### PR TITLE
More reliable global hotkey using KeyboardShortcuts

### DIFF
--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
 github "sindresorhus/LaunchAtLogin" "v3.0.0"
-github "sparkle-project/Sparkle" "1.22.0"
+github "sparkle-project/Sparkle" "v1.23.0"

--- a/Touch Bar Simulator.xcodeproj/project.pbxproj
+++ b/Touch Bar Simulator.xcodeproj/project.pbxproj
@@ -332,10 +332,6 @@
 				MACOSX_DEPLOYMENT_TARGET = 10.15;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
-				OTHER_LDFLAGS = (
-					"-weak_framework",
-					Combine,
-				);
 				SDKROOT = macosx;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_COMPILATION_MODE = singlefile;
@@ -389,10 +385,6 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 10.15;
 				MTL_ENABLE_DEBUG_INFO = NO;
-				OTHER_LDFLAGS = (
-					"-weak_framework",
-					Combine,
-				);
 				SDKROOT = macosx;
 				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_OPTIMIZATION_LEVEL = "-O";

--- a/Touch Bar Simulator.xcodeproj/project.pbxproj
+++ b/Touch Bar Simulator.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		3C48E6A6247C370E00D22565 /* KeyboardShortcuts in Frameworks */ = {isa = PBXBuildFile; productRef = 3C48E6A5247C370E00D22565 /* KeyboardShortcuts */; };
 		3C8493AD21FD3B7F00F12966 /* Glue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C8493AC21FD3B7F00F12966 /* Glue.swift */; };
 		3C906EED231C5FB90099B139 /* LaunchAtLogin.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3C906EEB231C5FB50099B139 /* LaunchAtLogin.framework */; };
 		3C906EEE231C5FB90099B139 /* LaunchAtLogin.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 3C906EEB231C5FB50099B139 /* LaunchAtLogin.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -75,6 +76,7 @@
 				E39A158A214D011F00F86D5D /* SkyLight.framework in Frameworks */,
 				3C906EED231C5FB90099B139 /* LaunchAtLogin.framework in Frameworks */,
 				E30988DF1E88DD060078CA9E /* Sparkle.framework in Frameworks */,
+				3C48E6A6247C370E00D22565 /* KeyboardShortcuts in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -159,6 +161,7 @@
 			name = "Touch Bar Simulator";
 			packageProductDependencies = (
 				E31957F823F140D500856B40 /* Defaults */,
+				3C48E6A5247C370E00D22565 /* KeyboardShortcuts */,
 			);
 			productName = "Touch Bar Simulator";
 			productReference = E3FE2CBF1E726CE800C6713A /* Touch Bar Simulator.app */;
@@ -196,6 +199,7 @@
 			mainGroup = E3FE2CB61E726CE800C6713A;
 			packageReferences = (
 				E31957F723F140D500856B40 /* XCRemoteSwiftPackageReference "Defaults" */,
+				3C48E6A4247C370E00D22565 /* XCRemoteSwiftPackageReference "KeyboardShortcuts" */,
 			);
 			productRefGroup = E3FE2CC01E726CE800C6713A /* Products */;
 			projectDirPath = "";
@@ -328,6 +332,10 @@
 				MACOSX_DEPLOYMENT_TARGET = 10.15;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
+				OTHER_LDFLAGS = (
+					"-weak_framework",
+					Combine,
+				);
 				SDKROOT = macosx;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_COMPILATION_MODE = singlefile;
@@ -381,6 +389,10 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 10.15;
 				MTL_ENABLE_DEBUG_INFO = NO;
+				OTHER_LDFLAGS = (
+					"-weak_framework",
+					Combine,
+				);
 				SDKROOT = macosx;
 				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
@@ -493,6 +505,14 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
+		3C48E6A4247C370E00D22565 /* XCRemoteSwiftPackageReference "KeyboardShortcuts" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/sindresorhus/KeyboardShortcuts";
+			requirement = {
+				kind = upToNextMinorVersion;
+				minimumVersion = 0.2.0;
+			};
+		};
 		E31957F723F140D500856B40 /* XCRemoteSwiftPackageReference "Defaults" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/sindresorhus/Defaults";
@@ -504,6 +524,11 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		3C48E6A5247C370E00D22565 /* KeyboardShortcuts */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 3C48E6A4247C370E00D22565 /* XCRemoteSwiftPackageReference "KeyboardShortcuts" */;
+			productName = KeyboardShortcuts;
+		};
 		E31957F823F140D500856B40 /* Defaults */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = E31957F723F140D500856B40 /* XCRemoteSwiftPackageReference "Defaults" */;

--- a/Touch Bar Simulator.xcodeproj/project.pbxproj
+++ b/Touch Bar Simulator.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		3C8493AD21FD3B7F00F12966 /* Glue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C8493AC21FD3B7F00F12966 /* Glue.swift */; };
 		3C906EED231C5FB90099B139 /* LaunchAtLogin.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3C906EEB231C5FB50099B139 /* LaunchAtLogin.framework */; };
 		3C906EEE231C5FB90099B139 /* LaunchAtLogin.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 3C906EEB231C5FB50099B139 /* LaunchAtLogin.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		3CF6C771247CC3DF007554B9 /* KeyboardShortcutsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CF6C770247CC3DF007554B9 /* KeyboardShortcutsView.swift */; };
 		AF6C7BC61E7FAF38004A27E0 /* ToolbarSlider.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF6C7BC51E7FAF38004A27E0 /* ToolbarSlider.swift */; };
 		E30988DF1E88DD060078CA9E /* Sparkle.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E30988DE1E88DD060078CA9E /* Sparkle.framework */; };
 		E30988E01E88DD060078CA9E /* Sparkle.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = E30988DE1E88DD060078CA9E /* Sparkle.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -49,6 +50,7 @@
 		3C37035321FBEBD300177657 /* Defaults.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Defaults.framework; path = Carthage/Build/Mac/Defaults.framework; sourceTree = "<group>"; };
 		3C8493AC21FD3B7F00F12966 /* Glue.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = Glue.swift; sourceTree = "<group>"; usesTabs = 1; };
 		3C906EEB231C5FB50099B139 /* LaunchAtLogin.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = LaunchAtLogin.framework; path = Carthage/Build/Mac/LaunchAtLogin.framework; sourceTree = "<group>"; };
+		3CF6C770247CC3DF007554B9 /* KeyboardShortcutsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardShortcutsView.swift; sourceTree = "<group>"; };
 		AF6C7BC51E7FAF38004A27E0 /* ToolbarSlider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = ToolbarSlider.swift; sourceTree = "<group>"; usesTabs = 1; };
 		E30988DE1E88DD060078CA9E /* Sparkle.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Sparkle.framework; path = Carthage/Build/Mac/Sparkle.framework; sourceTree = "<group>"; };
 		E34D6548214BBDAE00786C24 /* Touch Bar Simulator.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "Touch Bar Simulator.entitlements"; sourceTree = "<group>"; };
@@ -121,6 +123,7 @@
 				E35579EA21595EDC001CB642 /* TouchBarWindow.swift */,
 				E39A158D214D0C4F00F86D5D /* TouchBarView.swift */,
 				AF6C7BC51E7FAF38004A27E0 /* ToolbarSlider.swift */,
+				3CF6C770247CC3DF007554B9 /* KeyboardShortcutsView.swift */,
 				E3930B0F216625BE00F66410 /* Constants.swift */,
 				3C8493AC21FD3B7F00F12966 /* Glue.swift */,
 				E35831A31F4D7EE0003BE371 /* util.swift */,
@@ -270,6 +273,7 @@
 				E35831A41F4D7EE0003BE371 /* util.swift in Sources */,
 				AF6C7BC61E7FAF38004A27E0 /* ToolbarSlider.swift in Sources */,
 				3C8493AD21FD3B7F00F12966 /* Glue.swift in Sources */,
+				3CF6C771247CC3DF007554B9 /* KeyboardShortcutsView.swift in Sources */,
 				E356A16321028D81000148AD /* main.swift in Sources */,
 				E35579EB21595EDC001CB642 /* TouchBarWindow.swift in Sources */,
 				E3930B10216625BE00F66410 /* Constants.swift in Sources */,

--- a/Touch Bar Simulator/AppDelegate.swift
+++ b/Touch Bar Simulator/AppDelegate.swift
@@ -19,28 +19,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 		$0.button!.toolTip = "Right-click or option-click for menu"
 	}
 
-	struct KeyboardShortcutRecorder: SwiftUI.View {
-		var title: String
-		var shortcut: KeyboardShortcuts.Name
-		var body: some View {
-			HStack {
-				Text(title)
-				KeyboardShortcuts.Recorder(for: shortcut)
-			}
-		}
-	}
-
-	lazy var keyboardShortcutsVC = NSHostingController(rootView:
-		AnyView(
-			VStack(alignment: .center) {
-				Text("Keyboard Shortcuts:")
-				KeyboardShortcutRecorder(title: "Toggle Touch Bar", shortcut: .toggleTouchBar)
-			}
-			.padding(8)
-			.fixedSize()
-		)
-	)
-
 	func applicationWillFinishLaunching(_ notification: Notification) {
 		UserDefaults.standard.register(defaults: [
 			"NSApplicationCrashOnExceptions": true
@@ -160,7 +138,7 @@ extension AppDelegate: NSMenuDelegate {
 				return
 			}
 			let popover = NSPopover()
-			popover.contentViewController = self.keyboardShortcutsVC
+			popover.contentViewController = NSHostingController(rootView: KeyboardShortcutsView())
 			popover.behavior = .transient
 			popover.show(relativeTo: button.frame, of: button, preferredEdge: .maxY)
 		})

--- a/Touch Bar Simulator/AppDelegate.swift
+++ b/Touch Bar Simulator/AppDelegate.swift
@@ -49,12 +49,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
 	func applicationDidFinishLaunching(_ notification: Notification) {
 		checkAccessibilityPermission()
-		KeyboardShortcuts.onKeyUp(for: .toggleTouchBar) {
-			self.toggleView()
-		}
 		_ = SUUpdater()
 		_ = window
 		_ = statusItem
+		
+		KeyboardShortcuts.onKeyUp(for: .toggleTouchBar) {
+			self.toggleView()
+		}
 	}
 
 	func checkAccessibilityPermission() {

--- a/Touch Bar Simulator/AppDelegate.swift
+++ b/Touch Bar Simulator/AppDelegate.swift
@@ -30,7 +30,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 		_ = SUUpdater()
 		_ = window
 		_ = statusItem
-		
+
 		KeyboardShortcuts.onKeyUp(for: .toggleTouchBar) {
 			self.toggleView()
 		}

--- a/Touch Bar Simulator/Constants.swift
+++ b/Touch Bar Simulator/Constants.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Defaults
+import KeyboardShortcuts
 
 struct Constants {
 	static let windowAutosaveName = "TouchBarWindow"
@@ -13,4 +14,8 @@ extension Defaults.Keys {
 	static let lastFloatingPosition = OptionalKey<CGPoint>("lastFloatingPosition")
 	static let dockBehavior = Key<Bool>("dockBehavior", default: false)
 	static let lastWindowDockingWithDockBehavior = Key<TouchBarWindow.Docking>("windowDockingWithDockBehavior", default: .dockedToTop)
+}
+
+extension KeyboardShortcuts.Name {
+	static let toggleTouchBar = Name("toggleTouchBar")
 }

--- a/Touch Bar Simulator/Info.plist
+++ b/Touch Bar Simulator/Info.plist
@@ -26,22 +26,6 @@
 	<string>MIT License © Sindre Sorhus</string>
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
-	<key>NSServices</key>
-	<array>
-		<dict>
-			<key>NSKeyEquivalent</key>
-			<dict/>
-			<key>NSMenuItem</key>
-			<dict>
-				<key>default</key>
-				<string>Toggle Touch Bar</string>
-			</dict>
-			<key>NSMessage</key>
-			<string>toggleView</string>
-			<key>NSPortName</key>
-			<string>Touch Bar Simulator</string>
-		</dict>
-	</array>
 	<key>NSSupportsSuddenTermination</key>
 	<true/>
 	<key>SUEnableAutomaticChecks</key>

--- a/Touch Bar Simulator/KeyboardShortcutsView.swift
+++ b/Touch Bar Simulator/KeyboardShortcutsView.swift
@@ -1,0 +1,23 @@
+import SwiftUI
+import KeyboardShortcuts
+
+struct KeyboardShortcutsView: View {
+	private struct ShortcutRecorder: SwiftUI.View {
+		var title: String
+		var shortcut: KeyboardShortcuts.Name
+		var body: some View {
+			HStack {
+				Text(title + ":")
+				KeyboardShortcuts.Recorder(for: shortcut)
+			}
+		}
+	}
+
+	var body: some View {
+		VStack {
+			ShortcutRecorder(title: "Toggle Touch Bar", shortcut: .toggleTouchBar)
+		}
+		.padding()
+		.fixedSize()
+	}
+}

--- a/Touch Bar Simulator/KeyboardShortcutsView.swift
+++ b/Touch Bar Simulator/KeyboardShortcutsView.swift
@@ -17,8 +17,7 @@ struct KeyboardShortcutsView: View {
 		VStack {
 			ShortcutRecorder(title: "Toggle Touch Bar", shortcut: .toggleTouchBar)
 		}
-		.padding()
-		.padding(4)
+		.padding(20)
 		.fixedSize()
 	}
 }

--- a/Touch Bar Simulator/KeyboardShortcutsView.swift
+++ b/Touch Bar Simulator/KeyboardShortcutsView.swift
@@ -18,6 +18,7 @@ struct KeyboardShortcutsView: View {
 			ShortcutRecorder(title: "Toggle Touch Bar", shortcut: .toggleTouchBar)
 		}
 		.padding()
+		.padding(4)
 		.fixedSize()
 	}
 }

--- a/Touch Bar Simulator/KeyboardShortcutsView.swift
+++ b/Touch Bar Simulator/KeyboardShortcutsView.swift
@@ -1,23 +1,24 @@
 import SwiftUI
 import KeyboardShortcuts
 
-struct KeyboardShortcutsView: View {
-	private struct ShortcutRecorder: SwiftUI.View {
-		var title: String
-		var shortcut: KeyboardShortcuts.Name
-		var body: some View {
-			HStack {
-				Text(title + ":")
-				KeyboardShortcuts.Recorder(for: shortcut)
-			}
+private struct ShortcutRecorder: View {
+	var title: String
+	var shortcut: KeyboardShortcuts.Name
+
+	var body: some View {
+		HStack {
+			Text("\(title):")
+			KeyboardShortcuts.Recorder(for: shortcut)
 		}
 	}
+}
 
+struct KeyboardShortcutsView: View {
 	var body: some View {
 		VStack {
 			ShortcutRecorder(title: "Toggle Touch Bar", shortcut: .toggleTouchBar)
 		}
-		.padding(20)
-		.fixedSize()
+			.padding(20)
+			.fixedSize()
 	}
 }

--- a/readme.md
+++ b/readme.md
@@ -49,11 +49,7 @@ Apple would never allow it as it uses private APIs.
 
 ### Can I set a keyboard shortcut?
 
-You can set a shortcut to toggle the Touch Bar window using the included macOS Service.
-
-**tl;dr** `System Preferences` → `Keyboard` → `Shortcuts` → `Services` → `Toggle Touch Bar` → add your shortcut.
-
-Navigate to Keyboard in System Preferences, then click the Shortcuts tab and then Services in the list on the left. Scroll the list on the right down to the "General" section, then check the box beside "Toggle Touch Bar" and add your shortcut next to it.
+Yes, this is now integrated into the app. Right-click or option-click the menu bar icon, select "Keyboard Shortcuts…", and add your shortcut. 
 
 ### Can I contribute localizations?
 


### PR DESCRIPTION
I tore out the NSServices stuff (keyboard shortcuts for systemwide Services have always been unreliable at best…) and replaced it with your awesome KeyboardShortcuts library and a simple config popover.

<img src="https://user-images.githubusercontent.com/16456186/82837334-b8be8c80-9e96-11ea-8457-3a4bab78d6be.gif" width=400>

Should fix #68.